### PR TITLE
fix: historical data 30 days

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,7 +45,7 @@ export default function Dashboard() {
     async function fetchHistoricalData() {
       try {
         setHistoricalLoading(true);
-        const data = await getHistoricalPoolStats("9d", "15m");
+        const data = await getHistoricalPoolStats("30d", "30m");
         setHistoricalStats(data);
       } catch (error) {
         console.error("Error fetching historical stats:", error);
@@ -155,7 +155,7 @@ export default function Dashboard() {
         {/* <HashrateDistribution /> */}
       </div>
       <div className="w-full mb-6">
-        <HashrateTrends />
+        <HashrateTrends historicalData={historicalStats} loading={historicalLoading} />
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 w-full mb-6">
         <Leaderboard />


### PR DESCRIPTION
- Changed the historical data fetching period from 9 days with 15-minute intervals to 30 days with 30-minute intervals
- Modified the HashrateTrends component to accept historical data and loading state as props
- Removed unnecessary data fetching logic within HashrateTrends as 30d historical data is provided now