### PR TITLE
fix: add xverse wallet connection

### DIFF
--- a/app/components/ConnectButton.tsx
+++ b/app/components/ConnectButton.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useWallet } from '../hooks/useWallet';
+
+export default function ConnectButton() {
+  const { address, isConnected, connect, disconnect } = useWallet();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const shortenAddress = (addr: string) => {
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  };
+
+  const handleButtonClick = () => {
+    if (isConnected) {
+      setShowDropdown(!showDropdown);
+    } else {
+      connect();
+    }
+  };
+
+  const handleGoToProfile = () => {
+    if (address) {
+      router.push(`/user/${address}`);
+      setShowDropdown(false);
+    }
+  };
+
+  const handleDisconnect = () => {
+    disconnect();
+    setShowDropdown(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={handleButtonClick}
+        className="px-4 py-2 bg-foreground text-background hover:bg-gray-700 transition-colors text-xs sm:text-sm font-medium"
+      >
+        {isConnected && address ? shortenAddress(address) : 'Connect'}
+      </button>
+
+      {isConnected && showDropdown && (
+        <div className="absolute right-0 mt-2 w-48 bg-background border border-gray-300 shadow-lg z-50">
+          <button
+            onClick={handleGoToProfile}
+            className="w-full text-left px-4 py-2 hover:bg-gray-100 hover:text-black text-xs sm:text-sm transition-colors"
+          >
+            View
+          </button>
+          <button
+            onClick={handleDisconnect}
+            className="w-full text-left px-4 py-2 hover:bg-gray-100 hover:text-black text-xs sm:text-sm border-t border-gray-300 transition-colors"
+          >
+            Disconnect
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -7,6 +7,7 @@ import { useRef, KeyboardEvent, Dispatch, SetStateAction, useEffect } from 'reac
 import parasiteLogo from '@/public/parasite-white.png';
 import parasiteBug from '@/public/bug.png';
 import ErrorModal from './modals/ErrorModal';
+import ConnectButton from './ConnectButton';
 // import Counter from './Counter';
 
 interface NavigationProps {
@@ -84,12 +85,13 @@ export default function Navigation({
             </div>
         </div>
 
-        {/* Right: Counter */}
+        {/* Right: Connect Button */}
         <div className="flex-shrink-0 flex items-center space-x-4 w-auto sm:w-[200px] lg:w-[300px] justify-end">
           {/* <Counter value={0} /> */}
-          <Link href="/">
+          <ConnectButton />
+          {/* <Link href="/" className="hidden sm:block">
             <Image src={parasiteBug} alt="Parasite Bug" height={64} className='h-10 sm:h-12 w-auto' />
-          </Link>
+          </Link> */}
         </div>
 
         {/* Right: Pool status */}

--- a/app/hooks/useWallet.tsx
+++ b/app/hooks/useWallet.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
+import { AddressPurpose, request } from '@sats-connect/core';
+
+interface WalletContextType {
+  address: string | null;
+  isConnected: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+const WALLET_ADDRESS_KEY = 'parasite_wallet_address';
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // Restore wallet connection from localStorage on mount
+  useEffect(() => {
+    const savedAddress = localStorage.getItem(WALLET_ADDRESS_KEY);
+    if (savedAddress) {
+      setAddress(savedAddress);
+      setIsConnected(true);
+    }
+  }, []);
+
+  const addAddressToMonitoring = useCallback(async (addr: string) => {
+    try {
+      const response = await fetch('/api/user', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ address: addr })
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        if (response.status === 429) {
+          console.error('Too many addresses added recently');
+        } else {
+          console.error('Error adding address to monitoring:', data.error);
+        }
+      }
+    } catch (error) {
+      console.error('Error adding address to monitoring:', error);
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    try {
+      const response = await request('getAccounts', {
+        purposes: [AddressPurpose.Payment],
+        message: 'Connect your wallet to Parasite'
+      });
+
+      if (response.status === 'success') {
+        const paymentAddress = response.result.find(
+          (addr) => addr.purpose === AddressPurpose.Payment
+        );
+        if (paymentAddress) {
+          setAddress(paymentAddress.address);
+          setIsConnected(true);
+          // Save to localStorage for persistence
+          localStorage.setItem(WALLET_ADDRESS_KEY, paymentAddress.address);
+          // Add address to monitoring when connecting
+          await addAddressToMonitoring(paymentAddress.address);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to connect wallet:', error);
+    }
+  }, [addAddressToMonitoring]);
+
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setIsConnected(false);
+    // Clear localStorage on disconnect
+    localStorage.removeItem(WALLET_ADDRESS_KEY);
+  }, []);
+
+  return (
+    <WalletContext.Provider value={{ address, isConnected, connect, disconnect }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet() {
+  const context = useContext(WalletContext);
+  if (context === undefined) {
+    throw new Error('useWallet must be used within a WalletProvider');
+  }
+  return context;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import NavigationWrapper from "./components/NavigationWrapper";
 import Footer from "./components/Footer";
+import { WalletProvider } from "./hooks/useWallet";
 
 export const metadata: Metadata = {
   title: "Parasite",
@@ -44,11 +45,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`antialiased`}>
-        <div className="min-h-screen flex flex-col container mx-auto">
-          <NavigationWrapper />
-          {children}
-          <Footer />
-        </div>
+        <WalletProvider>
+          <div className="min-h-screen flex flex-col container mx-auto">
+            <NavigationWrapper />
+            {children}
+            <Footer />
+          </div>
+        </WalletProvider>
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@mempool/mempool.js": "3.0.0",
+    "@sats-connect/core": "^0.9.0",
     "better-sqlite3": "^11.10.0",
     "bitcoinjs-lib": "^6.1.7",
     "echarts": "5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ dependencies:
   '@mempool/mempool.js':
     specifier: 3.0.0
     version: 3.0.0
+  '@sats-connect/core':
+    specifier: ^0.9.0
+    version: 0.9.0(valibot@1.1.0)
   better-sqlite3:
     specifier: ^11.10.0
     version: 11.10.0
@@ -782,6 +785,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  /@noble/secp256k1@1.7.2:
+    resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -822,6 +829,20 @@ packages:
   /@rushstack/eslint-patch@1.11.0:
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
     dev: true
+
+  /@sats-connect/core@0.9.0(valibot@1.1.0):
+    resolution: {integrity: sha512-MKp195gyKv8nSPQxIhOmvkEiPdlfKSTXPq1pZujWUTTOXYoAawYeLzKlBOwz/f/X5SRLn8/qPD2rohF7xsWN3Q==}
+    peerDependencies:
+      valibot: 1.1.0
+    dependencies:
+      axios: 1.12.0
+      bitcoin-address-validation: 3.0.0
+      buffer: 6.0.3
+      jsontokens: 4.0.1
+      valibot: 1.1.0(typescript@5.8.3)
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /@sqltools/formatter@1.2.5:
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
@@ -1478,6 +1499,16 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /axios@1.12.0:
+    resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
     dependencies:
@@ -1574,6 +1605,11 @@ packages:
   /base-x@4.0.1:
     resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
 
+  /base58-js@3.0.3:
+    resolution: {integrity: sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: false
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
@@ -1601,6 +1637,14 @@ packages:
   /bip174@2.1.1:
     resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
     engines: {node: '>=8.0.0'}
+
+  /bitcoin-address-validation@3.0.0:
+    resolution: {integrity: sha512-R1X1c9EdgjgjTpjshjk5e16TbgF7HYasxBcu7l5ScWMxVs53845vMUg5PvnQ/R/3h8Grly6Y52DgH6/77gazLQ==}
+    dependencies:
+      base58-js: 3.0.3
+      bech32: 2.0.0
+      sha256-uint8array: 0.10.7
+    dev: false
 
   /bitcoinjs-lib@6.1.7:
     resolution: {integrity: sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==}
@@ -2959,6 +3003,14 @@ packages:
       minimist: 1.2.8
     dev: true
 
+  /jsontokens@4.0.1:
+    resolution: {integrity: sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==}
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@noble/secp256k1': 1.7.2
+      base64-js: 1.5.1
+    dev: false
+
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3781,6 +3833,10 @@ packages:
       to-buffer: 1.2.2
     dev: false
 
+  /sha256-uint8array@0.10.7:
+    resolution: {integrity: sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==}
+    dev: false
+
   /sharp@0.34.4:
     resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4297,7 +4353,6 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -4352,6 +4407,17 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+    dev: false
+
+  /valibot@1.1.0(typescript@5.8.3):
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.8.3
     dev: false
 
   /varuint-bitcoin@1.1.2:


### PR DESCRIPTION
This PR introduces a reusable WalletProvider/useWallet hook to manage wallet connections and persist state across sessions.

- Connects via @sats-connect/core getAccounts (Payment address)
- Persists the connected address in localStorage (WALLET_ADDRESS_KEY = 'parasite_wallet_address') and restores on load
- Adds the connected address to monitoring via POST /api/user
- Clears persisted state on disconnect
- Uses a provider/hook to make it easy to integrate into other components later