### PR TITLE
Add public pool-wide refinery orders endpoint

### DIFF
--- a/app/api/router/orders/route.ts
+++ b/app/api/router/orders/route.ts
@@ -1,6 +1,62 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { checkRateLimit, getRateLimitHeaders } from '@/app/api/lib/rate-limit';
+import { formatAddress } from '@/app/utils/formatters';
+import type { OrderStatus, OrderSummary, PublicOrderSummary } from '../types';
 
 export const dynamic = 'force-dynamic';
+
+const ALL_STATUSES: OrderStatus[] = [
+  'pending',
+  'in_mempool',
+  'active',
+  'fulfilled',
+  'cancelled',
+  'disconnected',
+  'expired',
+];
+
+const CURRENT_STATUSES: OrderStatus[] = ['active', 'pending', 'in_mempool'];
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+function toPublicOrder(order: OrderSummary): PublicOrderSummary {
+  return {
+    id: order.id,
+    status: order.status,
+    address: formatAddress(order.username.split('.')[0]),
+    requested_hash_days: order.requested_hash_days,
+    hashrate: order.hashrate,
+    delivered_hash_days: order.delivered_hash_days,
+    best_share: order.best_share,
+  };
+}
+
+function buildPublicOrders(
+  orders: OrderSummary[],
+  statuses: OrderStatus[] | null,
+  limit: number
+): PublicOrderSummary[] {
+  if (statuses) {
+    const wanted = new Set(statuses);
+    return orders
+      .filter(o => wanted.has(o.status))
+      .sort((a, b) => b.id - a.id)
+      .slice(0, limit)
+      .map(toPublicOrder);
+  }
+
+  // Default view: all current orders plus the most recent terminal ones
+  const currentSet = new Set(CURRENT_STATUSES);
+  const current = orders
+    .filter(o => currentSet.has(o.status))
+    .sort((a, b) => b.id - a.id);
+  const terminal = orders
+    .filter(o => !currentSet.has(o.status))
+    .sort((a, b) => b.id - a.id)
+    .slice(0, Math.max(0, limit - current.length));
+  return [...current, ...terminal].map(toPublicOrder);
+}
 
 export async function GET(request: NextRequest) {
   const routerBase = process.env.ROUTER_API_URL;
@@ -9,6 +65,37 @@ export async function GET(request: NextRequest) {
   }
 
   const address = request.nextUrl.searchParams.get('address');
+
+  // Public pool-wide view: rate-limited, validated params
+  let statuses: OrderStatus[] | null = null;
+  let limit = DEFAULT_LIMIT;
+  if (!address) {
+    const rateLimitResult = checkRateLimit(request);
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
+      );
+    }
+
+    const statusParam = request.nextUrl.searchParams.get('status');
+    if (statusParam) {
+      const parsed = statusParam.split(',').map(s => s.trim());
+      const invalid = parsed.filter(s => !ALL_STATUSES.includes(s as OrderStatus));
+      if (invalid.length > 0) {
+        return NextResponse.json(
+          { error: `Invalid status value(s): ${invalid.join(', ')}` },
+          { status: 400 }
+        );
+      }
+      statuses = parsed as OrderStatus[];
+    }
+
+    const limitParam = parseInt(request.nextUrl.searchParams.get('limit') || '', 10);
+    if (!isNaN(limitParam)) {
+      limit = Math.min(Math.max(limitParam, 1), MAX_LIMIT);
+    }
+  }
 
   try {
     const url = new URL(`${routerBase}/api/router/orders`);
@@ -21,7 +108,13 @@ export async function GET(request: NextRequest) {
     const contentType = res.headers.get('content-type') ?? '';
     if (contentType.includes('application/json')) {
       const data = await res.json();
-      return NextResponse.json(data, { status: res.status });
+      if (address || !res.ok || !Array.isArray(data)) {
+        return NextResponse.json(data, { status: res.status });
+      }
+      return NextResponse.json(buildPublicOrders(data, statuses, limit), {
+        status: 200,
+        headers: { 'Cache-Control': 's-maxage=30, stale-while-revalidate=60' },
+      });
     }
     if (contentType.includes('text/plain')) {
       const text = await res.text();

--- a/app/api/router/types.ts
+++ b/app/api/router/types.ts
@@ -93,6 +93,16 @@ export interface OrderDetail {
   sessions: SessionDetail[];
 }
 
+export interface PublicOrderSummary {
+  id: number;
+  status: OrderStatus;
+  address: string;
+  requested_hash_days: number | null;
+  hashrate: number;
+  delivered_hash_days: number;
+  best_share: number | null;
+}
+
 export interface OrderRequest {
   upstream_target: UpstreamTarget;
   hash_days: number;


### PR DESCRIPTION
## Summary
Extends `GET /api/router/orders` so that calling it **without** an `address` param returns a public, privacy-sanitized list of recent/current refinery orders across all users. Previously the no-address call was a raw passthrough of the upstream Router response (which would leak full miner addresses via `username`).

The upstream Router's `list_orders` handler returns all orders newest-first when no address is given, so this works with the deployed router as-is.

## Changes
- **Public view (no `address`)**:
  - Default: all `active`/`pending`/`in_mempool` orders plus the most recent terminal orders (`fulfilled`/`cancelled`/`disconnected`/`expired`), newest first
  - `?status=` comma-separated filter (400 on unknown values), `?limit=` clamped 1–100 (default 25)
  - Privacy: addresses truncated via `formatAddress()` (`bc1q...4444`); `username`, `endpoint`, and the upstream `review` moderation flag are stripped
  - Rate limited via shared `checkRateLimit`; `Cache-Control: s-maxage=30, stale-while-revalidate=60`
- **Per-user view (`?address=`)**: unchanged full passthrough (used by `Refinery.tsx`)
- New `PublicOrderSummary` type in `app/api/router/types.ts`

## Testing
- `tsc --noEmit` and `pnpm lint` pass
- Verified against a local mock router: default mixed view with truncated addresses, `?status=active` filtering, 400 on invalid status, per-user passthrough regression, and cache headers
- Cross-checked types against the real Router source: `OrderStatus` snake_case serialization matches the TS union exactly