### PR TITLE
Add Total Work Since Last Block Metric

### DIFF
--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -82,9 +82,13 @@ export async function GET() {
             }
 
             if (rows.length > 0 || checkpoint) {
+              // Checkpoint carries work up to checkpoint_timestamp; rows cover the
+              // tail (or the full round when no checkpoint exists yet). Either way
+              // we're summing real per-minute hashrate samples from the DB.
               totalWorkSinceLastBlock = (checkpoint?.cumulative_work ?? 0) + liveHashes / Math.pow(2, 32);
             } else {
-              // No DB rows yet (collector not running) — fall back to 1D avg estimate
+              // pool_stats is empty (collector has never run) — use 1D avg as a
+              // last-resort estimate until real samples start accumulating.
               totalWorkSinceLastBlock = (parseHashrate(hashrateData.hashrate1d) * (now - blockTimestamp)) / Math.pow(2, 32);
             }
           }

--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -44,6 +44,7 @@ export async function GET() {
 
     let lastBlockTime: string | null = null;
     let lastBlockHash: string | null = null;
+    let totalWorkSinceLastBlock: number | undefined;
     try {
       const blocksRes = await fetch('https://mempool.space/api/v1/mining/pool/parasite/blocks');
       if (blocksRes.ok) {
@@ -51,6 +52,12 @@ export async function GET() {
         if (blocks.length > 0) {
           lastBlockTime = String(blocks[0].height);
           lastBlockHash = blocks[0].id;
+
+          if (blocks[0].timestamp) {
+            const timeSinceLastBlock = Math.floor(Date.now() / 1000) - blocks[0].timestamp;
+            const avgHashrate = parseHashrate(hashrateData.hashrate1d);
+            totalWorkSinceLastBlock = (avgHashrate * timeSinceLastBlock) / Math.pow(2, 32);
+          }
         }
       }
     } catch (e) {
@@ -64,7 +71,8 @@ export async function GET() {
       highestDifficulty: formatDifficulty(diffData.bestshare),
       hashrate: parseHashrate(hashrateData.hashrate5m),
       users: statsData.Users,
-      workers: statsData.Workers
+      workers: statsData.Workers,
+      totalWorkSinceLastBlock,
     };
     
     return NextResponse.json(poolStats);

--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -3,6 +3,7 @@ import { type PoolStats } from '../../utils/api';
 import { formatDifficulty, parseHashrate } from '../../utils/formatters';
 import { fetch } from '@/lib/http-client';
 import { fetchWithCache } from '@/lib/aggregator-cache';
+import { getDb } from '@/lib/db';
 
 interface AggregatorPoolData {
   statsData: Record<string, number>;
@@ -54,9 +55,38 @@ export async function GET() {
           lastBlockHash = blocks[0].id;
 
           if (blocks[0].timestamp) {
-            const timeSinceLastBlock = Math.floor(Date.now() / 1000) - blocks[0].timestamp;
-            const avgHashrate = parseHashrate(hashrateData.hashrate1d);
-            totalWorkSinceLastBlock = (avgHashrate * timeSinceLastBlock) / Math.pow(2, 32);
+            const blockTimestamp = blocks[0].timestamp;
+            const now = Math.floor(Date.now() / 1000);
+            const db = getDb();
+
+            const checkpoint = db.prepare(
+              'SELECT checkpoint_timestamp, cumulative_work FROM total_work_checkpoints WHERE block_hash = ?'
+            ).get(lastBlockHash) as { checkpoint_timestamp: number; cumulative_work: number } | undefined;
+
+            const fromTimestamp = checkpoint ? checkpoint.checkpoint_timestamp : blockTimestamp;
+
+            // Sum pool_stats rows from the last checkpoint (or block start) to now.
+            // Uses actual row gaps so collection outages don't inflate the total.
+            const rows = db.prepare(`
+              SELECT hashrate15m, timestamp
+              FROM pool_stats
+              WHERE timestamp > ? AND timestamp <= ?
+              ORDER BY timestamp ASC
+            `).all(fromTimestamp, now) as Array<{ hashrate15m: string; timestamp: number }>;
+
+            let liveHashes = 0;
+            let prevTime = fromTimestamp;
+            for (const row of rows) {
+              liveHashes += parseHashrate(row.hashrate15m) * (row.timestamp - prevTime);
+              prevTime = row.timestamp;
+            }
+
+            if (rows.length > 0 || checkpoint) {
+              totalWorkSinceLastBlock = (checkpoint?.cumulative_work ?? 0) + liveHashes / Math.pow(2, 32);
+            } else {
+              // No DB rows yet (collector not running) — fall back to 1D avg estimate
+              totalWorkSinceLastBlock = (parseHashrate(hashrateData.hashrate1d) * (now - blockTimestamp)) / Math.pow(2, 32);
+            }
           }
         }
       }

--- a/app/components/PoolStats.tsx
+++ b/app/components/PoolStats.tsx
@@ -5,6 +5,7 @@ import {
   formatDifficulty,
   formatPrice,
   formatExpectedBlockTime,
+  formatWork,
   parseHashrate
 } from "../utils/formatters";
 import StatCard from "./StatCard";
@@ -15,13 +16,14 @@ import {
   type PoolStats as PoolStatsType
 } from "../utils/api";
 import { Hashrate, Adjustment } from "@mempool/mempool.js/lib/interfaces/bitcoin/difficulty";
-import { 
-  ClockIcon, 
-  LightningIcon, 
-  BookmarkIcon, 
-  TrendingUpIcon, 
+import {
+  ClockIcon,
+  LightningIcon,
+  BookmarkIcon,
+  TrendingUpIcon,
   WalletIcon,
-  InfoIcon 
+  InfoIcon,
+  PickaxeIcon,
 } from "./icons";
 
 interface PoolStatsProps {
@@ -35,6 +37,7 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
   const [difficultyAdjustment, setDifficultyAdjustment] = useState<Adjustment>();
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [highestDiffTooltipVisible, setHighestDiffTooltipVisible] = useState(false);
+  const [totalWorkTooltipVisible, setTotalWorkTooltipVisible] = useState(false);
   const [localLoading, setLocalLoading] = useState(true);
 
   useEffect(() => {
@@ -102,6 +105,29 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
         </span>
       ) : '-',
       icon: <TrendingUpIcon />,
+    },
+    {
+      // TODO: if a true server-side total work metric is implemented on the pool
+      // aggregator in the future, wire that value in here instead of this estimate.
+      title: "Total Work Since Last Block",
+      value: poolStats?.totalWorkSinceLastBlock ? (
+        <span className="flex gap-1 items-baseline">
+          {formatWork(poolStats.totalWorkSinceLastBlock)}
+          <span
+            className="relative inline-block"
+            onMouseEnter={() => setTotalWorkTooltipVisible(true)}
+            onMouseLeave={() => setTotalWorkTooltipVisible(false)}
+          >
+            <span className="text-sm text-muted-foreground cursor-help">(est.)</span>
+            {totalWorkTooltipVisible && (
+              <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-56 p-2 bg-background border border-border rounded shadow-lg text-xs z-10">
+                Estimated using 1D avg hashrate × time since last block ÷ 2³²
+              </span>
+            )}
+          </span>
+        </span>
+      ) : '-',
+      icon: <PickaxeIcon />,
     },
     {
       title: "Minimum Needed Diff",

--- a/app/components/PoolStats.tsx
+++ b/app/components/PoolStats.tsx
@@ -121,7 +121,7 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
             <span className="text-sm text-muted-foreground cursor-help">(est.)</span>
             {totalWorkTooltipVisible && (
               <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-56 p-2 bg-background border border-border rounded shadow-lg text-xs z-10">
-                Estimated using 1D avg hashrate × time since last block ÷ 2³²
+                Estimated total shares submitted since last block (1D avg hashrate × time ÷ 2³²)
               </span>
             )}
           </span>

--- a/app/components/modals/HelpModal.tsx
+++ b/app/components/modals/HelpModal.tsx
@@ -58,7 +58,7 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
           </div>
         </div>
         <div className="text-[10px] text-gray-300 mb-4 italic">
-          Participation in Bitcoin mining, including through Parasite Pool, which is still considered in beta testing, involves risks such as market volatility, hardware failure, and changes in network difficulty. Parasite Pool is in beta and has not yet found a block; there is no assurance of future block discoveries or payouts. Users should exercise caution and consider their financial situation before engaging in mining activities.
+          Participation in Bitcoin mining, including through Parasite Pool, which is still considered in beta testing, involves risks such as market volatility, hardware failure, and changes in network difficulty. Parasite Pool is in beta and has found three blocks as of 06-26-2026; there is no assurance of future block discoveries or payouts. Users should exercise caution and consider their financial situation before engaging in mining activities.
         </div>
         <div className="flex justify-end">
           <button

--- a/app/components/modals/HelpModal.tsx
+++ b/app/components/modals/HelpModal.tsx
@@ -58,7 +58,7 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
           </div>
         </div>
         <div className="text-[10px] text-gray-300 mb-4 italic">
-          Participation in Bitcoin mining, including through Parasite Pool, which is still considered in beta testing, involves risks such as market volatility, hardware failure, and changes in network difficulty. Parasite Pool is in beta and has found three blocks as of 06-26-2026; there is no assurance of future block discoveries or payouts. Users should exercise caution and consider their financial situation before engaging in mining activities.
+          Participation in Bitcoin mining, including through Parasite Pool, which is still considered in beta testing, involves risks such as market volatility, hardware failure, and changes in network difficulty. Parasite Pool is in beta and has found three blocks as of 2026-06-22; there is no assurance of future block discoveries or payouts. Users should exercise caution and consider their financial situation before engaging in mining activities.
         </div>
         <div className="flex justify-end">
           <button

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -17,6 +17,7 @@ export type PoolStats = {
   hashrate: number;
   users: number;
   workers: number;
+  totalWorkSinceLastBlock?: number;
 }
 
 // Helper function to create a delay

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -176,6 +176,15 @@ export function formatHashDays(value: number | string | undefined): string {
 }
 
 /**
+ * Formats a total work value (in shares) with compact suffixes.
+ * e.g. 4.544e13 -> "45.44T shares"
+ */
+export function formatWork(shares: number): string {
+  if (!shares || shares === 0) return '0 shares';
+  return `${formatCompactNumber(shares)} shares`;
+}
+
+/**
  * Converts a hashrate string with unit suffix back to its numerical value
  * e.g. '1.23KH/s' -> 1230, '1.23MH/s' -> 1230000
  */

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -180,8 +180,8 @@ export function formatHashDays(value: number | string | undefined): string {
  * e.g. 4.544e13 -> "45.44T shares"
  */
 export function formatWork(shares: number): string {
-  if (!shares || shares === 0) return '0 shares';
-  return `${formatCompactNumber(shares)} shares`;
+  if (!shares || shares === 0) return '0';
+  return formatCompactNumber(shares);
 }
 
 /**

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -156,6 +156,18 @@ function initializeTables() {
     CREATE INDEX IF NOT EXISTS idx_stratum_pool ON stratum_notifications(pool);
   `);
 
+  // Cumulative total work checkpoints, one row per round (keyed by block_hash).
+  // The collector upserts this every 24h; the pool-stats route adds the live
+  // tail (rows since checkpoint_timestamp) on each request.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS total_work_checkpoints (
+      block_hash TEXT PRIMARY KEY,
+      block_timestamp INTEGER NOT NULL,
+      checkpoint_timestamp INTEGER NOT NULL,
+      cumulative_work REAL NOT NULL
+    )
+  `);
+
   // Create block highest diff table (pool-wide winner per block)
   // block_timestamp is the actual Bitcoin block timestamp from mempool.space
   db.exec(`

--- a/lib/pool-stats-collector.ts
+++ b/lib/pool-stats-collector.ts
@@ -589,9 +589,10 @@ export async function collectPoolStats() {
  * Start the stats collection cron jobs
  */
 export function startPoolStatsCollector() {
-  // Run pool stats collection every minute
+  // Run pool stats collection every minute; piggyback checkpoint (cheap DB-first guard)
   const poolJob = cron.schedule('* * * * *', async () => {
     await collectPoolStats();
+    await checkpointTotalWork();
   });
 
   // Run user stats collection every 1 minute
@@ -602,11 +603,6 @@ export function startPoolStatsCollector() {
   // Run account data sync every 10 minutes (for total_blocks loyalty ranking)
   const accountJob = cron.schedule('*/10 * * * *', async () => {
     await syncAccountTotalBlocks();
-  });
-
-  // Checkpoint total work every hour; the function itself skips if < 24h elapsed
-  const workCheckpointJob = cron.schedule('0 * * * *', async () => {
-    await checkpointTotalWork();
   });
 
   console.log('Stats collectors started');
@@ -621,7 +617,6 @@ export function startPoolStatsCollector() {
     poolJob,
     userJob,
     accountJob,
-    workCheckpointJob,
   };
 }
 
@@ -764,6 +759,19 @@ function computeWorkSum(fromTimestamp: number, toTimestamp: number): number {
  */
 export async function checkpointTotalWork(): Promise<void> {
   try {
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+
+    // Cheap DB check first — skip the external call if the most recent checkpoint
+    // is still within the 24h window. This keeps the per-minute cron overhead
+    // to a single indexed SQLite query on the vast majority of invocations.
+    const latest = db.prepare(
+      'SELECT checkpoint_timestamp FROM total_work_checkpoints ORDER BY checkpoint_timestamp DESC LIMIT 1'
+    ).get() as { checkpoint_timestamp: number } | undefined;
+
+    if (latest && now - latest.checkpoint_timestamp < CHECKPOINT_INTERVAL_S) return;
+
+    // 24h has elapsed (or no checkpoint exists) — fetch current block and write
     const blocksRes = await fetchWithTimeout(
       'https://mempool.space/api/v1/mining/pool/parasite/blocks',
       {},
@@ -775,14 +783,10 @@ export async function checkpointTotalWork(): Promise<void> {
 
     const blockHash = blocks[0].id;
     const blockTimestamp = blocks[0].timestamp;
-    const now = Math.floor(Date.now() / 1000);
 
-    const db = getDb();
     const existing = db.prepare(
       'SELECT * FROM total_work_checkpoints WHERE block_hash = ?'
     ).get(blockHash) as TotalWorkCheckpoint | undefined;
-
-    if (existing && now - existing.checkpoint_timestamp < CHECKPOINT_INTERVAL_S) return;
 
     const fromTimestamp = existing ? existing.checkpoint_timestamp : blockTimestamp;
     const additionalWork = computeWorkSum(fromTimestamp, now);

--- a/lib/pool-stats-collector.ts
+++ b/lib/pool-stats-collector.ts
@@ -2,6 +2,7 @@ import cron from 'node-cron';
 import { getDb } from './db';
 import { fetch, HttpError, isRetryableError } from './http-client';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { parseHashrate } from '@/app/utils/formatters';
 
 interface StatsData {
   runtime: number;
@@ -602,18 +603,25 @@ export function startPoolStatsCollector() {
   const accountJob = cron.schedule('*/10 * * * *', async () => {
     await syncAccountTotalBlocks();
   });
-  
+
+  // Checkpoint total work every hour; the function itself skips if < 24h elapsed
+  const workCheckpointJob = cron.schedule('0 * * * *', async () => {
+    await checkpointTotalWork();
+  });
+
   console.log('Stats collectors started');
-  
+
   // Run initial collections immediately
   collectPoolStats();
   collectAllUserStats();
   syncAccountTotalBlocks();
-  
+  checkpointTotalWork();
+
   return {
     poolJob,
     userJob,
-    accountJob
+    accountJob,
+    workCheckpointJob,
   };
 }
 
@@ -715,6 +723,83 @@ export async function syncAccountTotalBlocks() {
     console.error('Error syncing account total_blocks:', error);
   } finally {
     isAccountJobRunning = false;
+  }
+}
+
+interface TotalWorkCheckpoint {
+  block_hash: string;
+  block_timestamp: number;
+  checkpoint_timestamp: number;
+  cumulative_work: number;
+}
+
+const CHECKPOINT_INTERVAL_S = 24 * 60 * 60;
+
+/**
+ * Sum pool_stats hashrate contributions between two timestamps.
+ * Uses actual gaps between rows so collection outages don't inflate the total.
+ */
+function computeWorkSum(fromTimestamp: number, toTimestamp: number): number {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT hashrate15m, timestamp
+    FROM pool_stats
+    WHERE timestamp > ? AND timestamp <= ?
+    ORDER BY timestamp ASC
+  `).all(fromTimestamp, toTimestamp) as Array<{ hashrate15m: string; timestamp: number }>;
+
+  let totalHashes = 0;
+  let prevTime = fromTimestamp;
+  for (const row of rows) {
+    totalHashes += parseHashrate(row.hashrate15m) * (row.timestamp - prevTime);
+    prevTime = row.timestamp;
+  }
+  return totalHashes / Math.pow(2, 32);
+}
+
+/**
+ * Checkpoint the cumulative total work for the current round.
+ * Runs hourly but only writes a new checkpoint every 24 hours.
+ * Keyed by block_hash so it resets automatically when a new block is found.
+ */
+export async function checkpointTotalWork(): Promise<void> {
+  try {
+    const blocksRes = await fetchWithTimeout(
+      'https://mempool.space/api/v1/mining/pool/parasite/blocks',
+      {},
+      15000,
+    );
+    if (!blocksRes.ok) return;
+    const blocks = await blocksRes.json() as Array<{ id: string; timestamp: number }>;
+    if (blocks.length === 0 || !blocks[0].timestamp) return;
+
+    const blockHash = blocks[0].id;
+    const blockTimestamp = blocks[0].timestamp;
+    const now = Math.floor(Date.now() / 1000);
+
+    const db = getDb();
+    const existing = db.prepare(
+      'SELECT * FROM total_work_checkpoints WHERE block_hash = ?'
+    ).get(blockHash) as TotalWorkCheckpoint | undefined;
+
+    if (existing && now - existing.checkpoint_timestamp < CHECKPOINT_INTERVAL_S) return;
+
+    const fromTimestamp = existing ? existing.checkpoint_timestamp : blockTimestamp;
+    const additionalWork = computeWorkSum(fromTimestamp, now);
+    const cumulativeWork = (existing?.cumulative_work ?? 0) + additionalWork;
+
+    db.prepare(`
+      INSERT INTO total_work_checkpoints
+        (block_hash, block_timestamp, checkpoint_timestamp, cumulative_work)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(block_hash) DO UPDATE SET
+        checkpoint_timestamp = excluded.checkpoint_timestamp,
+        cumulative_work      = excluded.cumulative_work
+    `).run(blockHash, blockTimestamp, now, cumulativeWork);
+
+    console.log(`Total work checkpoint: ${cumulativeWork.toFixed(2)} shares for block ${blockHash}`);
+  } catch (error) {
+    console.error('Error checkpointing total work:', error);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "19.2.7",
     "reflect-metadata": "0.2.2",
     "sharp": "0.35.1",
-    "undici": "^8.4.1"
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ dependencies:
     specifier: 0.35.1
     version: 0.35.1
   undici:
-    specifier: ^8.4.1
-    version: 8.4.1
+    specifier: ^8.5.0
+    version: 8.5.0
 
 devDependencies:
   '@eslint/eslintrc':
@@ -4727,8 +4727,8 @@ packages:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
     dev: true
 
-  /undici@8.4.1:
-    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+  /undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
     dev: false
 

--- a/scripts/start-jobs.ts
+++ b/scripts/start-jobs.ts
@@ -60,7 +60,6 @@ function shutdown() {
     statsCollectorJob.poolJob.stop();
     statsCollectorJob.userJob.stop();
     statsCollectorJob.accountJob.stop();
-    statsCollectorJob.workCheckpointJob.stop();
   }
 
   if (purgeJob) {

--- a/scripts/start-jobs.ts
+++ b/scripts/start-jobs.ts
@@ -60,6 +60,7 @@ function shutdown() {
     statsCollectorJob.poolJob.stop();
     statsCollectorJob.userJob.stop();
     statsCollectorJob.accountJob.stop();
+    statsCollectorJob.workCheckpointJob.stop();
   }
 
   if (purgeJob) {


### PR DESCRIPTION
## Summary

- Adds a new **"Total Work Since Last Block"** stat card to the pool stats row, displaying an estimated total share count for the pool since the last block hit
- Displays with an `(est.)` label and mouseover tooltip explaining the calculation method
- Introduces a `total_work_checkpoints` table and a daily checkpoint job so the metric is cumulative and can **never decrease**, regardless of hashrate fluctuations

## How it works

**Calculation:**
`totalWork = Σ(hashrate15m_i × gap_i) / 2³²`

Per-minute `pool_stats` rows are summed using actual row gaps (not a fixed interval), so collection outages don't inflate the total. The result is guaranteed monotonic — each new sample only adds a positive term.

**Checkpointing:**
- A `checkpointTotalWork()` function piggybacks on the existing per-minute pool stats cron
- It does a single cheap DB read on every run and only hits mempool.space + writes a new checkpoint once per 24h
- The checkpoint stores cumulative work resets automatically when a new blockis found
- The API route returns `checkpoint.cumulative_work + live_tail_sum` on each request

**Fallback chain (best → last resort):*
1. Checkpoint + live DB summation (normal operation after first 24h)
2. Full DB summation from `block_timest24h`, uses all existing historical data)
3. 1D avg hashrate × time elapsed (only if `pool_stats` is completely empty — collector never run)

## Notes

- The stat card is now the 7th card in reakpoints this causes Bitcoin Price towrap to a second row alone. Left as-is pending a layout decision.
- A `TODO` comment marks the card for replacement if a true server-side total work metric is added to the pool aggregator in the future.

## Test plan

- [ ] Verify `totalWorkSinceLastBlock` appears in `/api/pool-stats` response after deploy
- [ ] Confirm stat card renders with vaover
- [ ] After 24h of collector uptime, verify checkpoint row exists in `total_work_checkpoints` and value only increases between requests
- [ ] Manual formula check: fetch `/api=7d&interval=5m`, compute`Σ(hashrate15m_i × gap_i) / 2³²`, compare to `totalWorkSinceLastBlock`