### PR TITLE
feat: counted work per round + pool work since last block

### DIFF
--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -3,6 +3,25 @@ import { type PoolStats } from '../../utils/api';
 import { formatDifficulty, parseHashrate } from '../../utils/formatters';
 import { fetch } from '@/lib/http-client';
 import { fetchWithCache } from '@/lib/aggregator-cache';
+import { getDb } from '@/lib/db';
+
+/**
+ * Pool-wide counted work since the last block = sum of every participant's
+ * accepted share difficulty in the current round (block_height = 0 sentinel),
+ * synced from the backend by the rounds collector. Returns null when no
+ * current-round data has been collected yet, rather than a misleading 0.
+ */
+function getWorkSinceLastBlock(): number | null {
+  try {
+    const row = getDb()
+      .prepare('SELECT SUM(total_work) AS work FROM round_participants WHERE block_height = 0')
+      .get() as { work: number | null } | undefined;
+    return row?.work ?? null;
+  } catch (error) {
+    console.error('Error computing work since last block:', error);
+    return null;
+  }
+}
 
 interface AggregatorPoolData {
   statsData: Record<string, number>;
@@ -64,7 +83,8 @@ export async function GET() {
       highestDifficulty: formatDifficulty(diffData.bestshare),
       hashrate: parseHashrate(hashrateData.hashrate5m),
       users: statsData.Users,
-      workers: statsData.Workers
+      workers: statsData.Workers,
+      workSinceLastBlock: getWorkSinceLastBlock()
     };
     
     return NextResponse.json(poolStats);

--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -5,12 +5,8 @@ import { fetch } from '@/lib/http-client';
 import { fetchWithCache } from '@/lib/aggregator-cache';
 import { getDb } from '@/lib/db';
 
-/**
- * Pool-wide counted work since the last block = sum of every participant's
- * accepted share difficulty in the current round (block_height = 0 sentinel),
- * synced from the backend by the rounds collector. Returns null when no
- * current-round data has been collected yet, rather than a misleading 0.
- */
+// Sum of the current round's per-user work (block_height 0). null, not 0, when
+// the collector has no current-round data yet.
 function getWorkSinceLastBlock(): number | null {
   try {
     const row = getDb()

--- a/app/api/rounds/types.ts
+++ b/app/api/rounds/types.ts
@@ -7,6 +7,7 @@ export interface RoundParticipantRow {
   username: string;
   top_diff: number;
   blocks_participated: number;
+  total_work: number;
 }
 
 export interface RoundRow {
@@ -32,10 +33,12 @@ export function queryRoundParticipants(
 ) {
   const orderBy = type === 'participation'
     ? 'blocks_participated DESC'
-    : 'top_diff DESC';
+    : type === 'work'
+      ? 'total_work DESC'
+      : 'top_diff DESC';
 
   const rows = db.prepare(`
-    SELECT rp.username, rp.top_diff, rp.blocks_participated
+    SELECT rp.username, rp.top_diff, rp.blocks_participated, rp.total_work
     FROM round_participants rp
     LEFT JOIN monitored_users m ON rp.username = m.address
     WHERE rp.block_height = ? AND (m.is_public = 1 OR m.address IS NULL)
@@ -49,5 +52,6 @@ export function queryRoundParticipants(
     claimed: claimedSet.has(row.username),
     top_diff: row.top_diff,
     blocks_participated: row.blocks_participated,
+    total_work: row.total_work,
   }));
 }

--- a/app/api/user/[address]/rounds/route.ts
+++ b/app/api/user/[address]/rounds/route.ts
@@ -5,9 +5,11 @@ export interface UserRoundHistoryEntry {
   block_height: number;
   rank: number;
   blocks_rank: number;
+  work_rank: number;
   total_participants: number;
   top_diff: number;
   blocks_participated: number;
+  total_work: number;
   is_winner: boolean;
 }
 
@@ -15,9 +17,11 @@ export interface UserRoundsResponse {
   current_round: {
     rank: number;
     blocks_rank: number;
+    work_rank: number;
     total_participants: number;
     top_diff: number;
     blocks_participated: number;
+    total_work: number;
   } | null;
   rounds_won: number;
   total_rounds_participated: number;
@@ -49,8 +53,8 @@ export async function GET(
 
     // Current round (block_height = 0 sentinel)
     const currentUser = db.prepare(
-      `SELECT top_diff, blocks_participated FROM round_participants WHERE block_height = 0 AND username = ?`
-    ).get(address) as { top_diff: number; blocks_participated: number } | undefined;
+      `SELECT top_diff, blocks_participated, total_work FROM round_participants WHERE block_height = 0 AND username = ?`
+    ).get(address) as { top_diff: number; blocks_participated: number; total_work: number } | undefined;
 
     let current_round: UserRoundsResponse['current_round'] = null;
 
@@ -59,16 +63,19 @@ export async function GET(
         SELECT
           COUNT(CASE WHEN top_diff > ? THEN 1 END) + 1 AS rank,
           COUNT(CASE WHEN blocks_participated > ? THEN 1 END) + 1 AS blocks_rank,
+          COUNT(CASE WHEN total_work > ? THEN 1 END) + 1 AS work_rank,
           COUNT(*) AS total
         FROM round_participants WHERE block_height = 0
-      `).get(currentUser.top_diff, currentUser.blocks_participated) as { rank: number; blocks_rank: number; total: number };
+      `).get(currentUser.top_diff, currentUser.blocks_participated, currentUser.total_work) as { rank: number; blocks_rank: number; work_rank: number; total: number };
 
       current_round = {
         rank: rankInfo.rank,
         blocks_rank: rankInfo.blocks_rank,
+        work_rank: rankInfo.work_rank,
         total_participants: rankInfo.total,
         top_diff: currentUser.top_diff,
         blocks_participated: currentUser.blocks_participated,
+        total_work: currentUser.total_work,
       };
     }
 
@@ -93,8 +100,10 @@ export async function GET(
           rp.username,
           rp.top_diff,
           rp.blocks_participated,
+          rp.total_work,
           RANK() OVER (PARTITION BY rp.block_height ORDER BY rp.top_diff DESC) AS rank,
           RANK() OVER (PARTITION BY rp.block_height ORDER BY rp.blocks_participated DESC) AS blocks_rank,
+          RANK() OVER (PARTITION BY rp.block_height ORDER BY rp.total_work DESC) AS work_rank,
           COUNT(*) OVER (PARTITION BY rp.block_height) AS total_participants
         FROM round_participants rp
         INNER JOIN user_blocks ub ON ub.block_height = rp.block_height
@@ -104,8 +113,10 @@ export async function GET(
         ranked.block_height,
         ranked.top_diff,
         ranked.blocks_participated,
+        ranked.total_work,
         ranked.rank,
         ranked.blocks_rank,
+        ranked.work_rank,
         ranked.total_participants,
         CASE WHEN r.winner_username = ? THEN 1 ELSE 0 END AS is_winner
       FROM ranked
@@ -117,8 +128,10 @@ export async function GET(
       block_height: number;
       top_diff: number;
       blocks_participated: number;
+      total_work: number;
       rank: number;
       blocks_rank: number;
+      work_rank: number;
       total_participants: number;
       is_winner: number;
     }[];
@@ -131,9 +144,11 @@ export async function GET(
         block_height: row.block_height,
         rank: row.rank,
         blocks_rank: row.blocks_rank,
+        work_rank: row.work_rank,
         total_participants: row.total_participants,
         top_diff: row.top_diff,
         blocks_participated: row.blocks_participated,
+        total_work: row.total_work,
         is_winner: row.is_winner === 1,
       })),
     };

--- a/app/components/PoolStats.tsx
+++ b/app/components/PoolStats.tsx
@@ -21,8 +21,7 @@ import {
   BookmarkIcon,
   TrendingUpIcon,
   WalletIcon,
-  InfoIcon,
-  PickaxeIcon
+  InfoIcon
 } from "./icons";
 
 interface PoolStatsProps {
@@ -35,7 +34,6 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
   const [bitcoinPrice, setBitcoinPrice] = useState<number | null>(null);
   const [difficultyAdjustment, setDifficultyAdjustment] = useState<Adjustment>();
   const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [highestDiffTooltipVisible, setHighestDiffTooltipVisible] = useState(false);
   const [workTooltipVisible, setWorkTooltipVisible] = useState(false);
   const [localLoading, setLocalLoading] = useState(true);
 
@@ -83,48 +81,39 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
 
   const statCards = [
     {
-      title: "Highest Diff Since Last Block",
-      value: poolStats?.highestDifficulty && hashrate?.currentDifficulty ? (
-        <span className='flex gap-1'>
-          {poolStats.highestDifficulty}
-          <span 
-            className="relative inline-block"
-            onMouseEnter={() => setHighestDiffTooltipVisible(true)}
-            onMouseLeave={() => setHighestDiffTooltipVisible(false)}
-          >
-            <span className="text-sm text-muted-foreground cursor-help">
-              ({Number(((parseHashrate(poolStats.highestDifficulty) / hashrate.currentDifficulty) * 100).toFixed(2))}%)
+      title: "Since Last Block",
+      value: (
+        <div className="text-lg leading-tight space-y-1">
+          <div className="flex items-baseline gap-2">
+            <span className="text-xs text-accent-2 w-11 shrink-0">Diff</span>
+            {poolStats?.highestDifficulty && hashrate?.currentDifficulty ? (
+              <span className="flex items-baseline gap-1">
+                {poolStats.highestDifficulty}
+                <span className="text-xs text-muted-foreground">
+                  ({Number(((parseHashrate(poolStats.highestDifficulty) / hashrate.currentDifficulty) * 100).toFixed(1))}%)
+                </span>
+              </span>
+            ) : '-'}
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-xs text-accent-2 w-11 shrink-0">Work</span>
+            <span>{poolStats?.workSinceLastBlock != null ? formatDifficulty(poolStats.workSinceLastBlock) : '-'}</span>
+            <span
+              className="relative inline-block cursor-help self-center"
+              onMouseEnter={() => setWorkTooltipVisible(true)}
+              onMouseLeave={() => setWorkTooltipVisible(false)}
+            >
+              <InfoIcon className="h-4 w-4 text-accent-3 p-0.5" />
+              {workTooltipVisible && (
+                <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-60 p-2 bg-background border border-border rounded shadow-lg text-xs z-10 font-normal normal-case">
+                  Diff = highest share difficulty since the last block (and its % of network difficulty). Work = counted sum of every miner&apos;s accepted share difficulty this round.
+                </span>
+              )}
             </span>
-            {highestDiffTooltipVisible && (
-              <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-48 p-2 bg-background border border-border rounded shadow-lg text-xs z-10">
-                Percentage of the current network difficulty
-              </span>
-            )}
-          </span>
-        </span>
-      ) : '-',
+          </div>
+        </div>
+      ),
       icon: <TrendingUpIcon />,
-    },
-    {
-      title: "Work Since Last Block",
-      value: poolStats?.workSinceLastBlock != null ? (
-        <span className="flex items-center gap-1">
-          {formatDifficulty(poolStats.workSinceLastBlock)}
-          <span
-            className="relative inline-block cursor-help"
-            onMouseEnter={() => setWorkTooltipVisible(true)}
-            onMouseLeave={() => setWorkTooltipVisible(false)}
-          >
-            <InfoIcon className="h-4 w-4 text-accent-3 p-0.5" />
-            {workTooltipVisible && (
-              <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-56 p-2 bg-background border border-border rounded shadow-lg text-xs z-10 font-normal normal-case">
-                Counted pool work since the last block — the sum of every miner&apos;s accepted share difficulty this round. Updates every few minutes.
-              </span>
-            )}
-          </span>
-        </span>
-      ) : '-',
-      icon: <PickaxeIcon />,
     },
     {
       title: "Minimum Needed Diff",
@@ -181,15 +170,16 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
 
   return (
     <div className="w-full">
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2 lg:gap-3">
+      <div className="flex flex-wrap -mx-2">
         {statCards.map((card, index) => (
-          <StatCard
-            key={index}
-            title={card.title}
-            value={card.value}
-            icon={card.icon}
-            loading={loading || localLoading}
-          />
+          <div key={index} className="w-1/2 md:w-1/3 lg:w-1/6 p-1 lg:p-2">
+            <StatCard
+              title={card.title}
+              value={card.value}
+              icon={card.icon}
+              loading={loading || localLoading}
+            />
+          </div>
         ))}
       </div>
     </div>

--- a/app/components/PoolStats.tsx
+++ b/app/components/PoolStats.tsx
@@ -15,13 +15,14 @@ import {
   type PoolStats as PoolStatsType
 } from "../utils/api";
 import { Hashrate, Adjustment } from "@mempool/mempool.js/lib/interfaces/bitcoin/difficulty";
-import { 
-  ClockIcon, 
-  LightningIcon, 
-  BookmarkIcon, 
-  TrendingUpIcon, 
+import {
+  ClockIcon,
+  LightningIcon,
+  BookmarkIcon,
+  TrendingUpIcon,
   WalletIcon,
-  InfoIcon 
+  InfoIcon,
+  PickaxeIcon
 } from "./icons";
 
 interface PoolStatsProps {
@@ -35,6 +36,7 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
   const [difficultyAdjustment, setDifficultyAdjustment] = useState<Adjustment>();
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [highestDiffTooltipVisible, setHighestDiffTooltipVisible] = useState(false);
+  const [workTooltipVisible, setWorkTooltipVisible] = useState(false);
   const [localLoading, setLocalLoading] = useState(true);
 
   useEffect(() => {
@@ -104,6 +106,27 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
       icon: <TrendingUpIcon />,
     },
     {
+      title: "Work Since Last Block",
+      value: poolStats?.workSinceLastBlock != null ? (
+        <span className="flex items-center gap-1">
+          {formatDifficulty(poolStats.workSinceLastBlock)}
+          <span
+            className="relative inline-block cursor-help"
+            onMouseEnter={() => setWorkTooltipVisible(true)}
+            onMouseLeave={() => setWorkTooltipVisible(false)}
+          >
+            <InfoIcon className="h-4 w-4 text-accent-3 p-0.5" />
+            {workTooltipVisible && (
+              <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 -translate-y-2 w-56 p-2 bg-background border border-border rounded shadow-lg text-xs z-10 font-normal normal-case">
+                Counted pool work since the last block — the sum of every miner&apos;s accepted share difficulty this round. Updates every few minutes.
+              </span>
+            )}
+          </span>
+        </span>
+      ) : '-',
+      icon: <PickaxeIcon />,
+    },
+    {
       title: "Minimum Needed Diff",
       value: (
         <div className="flex items-baseline">
@@ -158,16 +181,15 @@ export default function PoolStats({ poolStats, loading }: PoolStatsProps) {
 
   return (
     <div className="w-full">
-      <div className="flex flex-wrap -mx-2">
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2 lg:gap-3">
         {statCards.map((card, index) => (
-          <div key={index} className="w-1/2 md:w-1/3 lg:w-1/6 p-1 lg:p-2">
-            <StatCard
-              title={card.title}
-              value={card.value}
-              icon={card.icon}
-              loading={loading || localLoading}
-            />
-          </div>
+          <StatCard
+            key={index}
+            title={card.title}
+            value={card.value}
+            icon={card.icon}
+            loading={loading || localLoading}
+          />
         ))}
       </div>
     </div>

--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -19,6 +19,7 @@ interface RoundParticipant {
   claimed: boolean;
   top_diff: number;
   blocks_participated: number;
+  total_work: number;
 }
 
 interface ParticipantRow {
@@ -27,10 +28,11 @@ interface ParticipantRow {
   claimed: boolean;
   top_diff: number;
   blocks_participated: number;
+  total_work: number;
   rank: number;
 }
 
-type LeaderboardType = 'difficulty' | 'participation';
+type LeaderboardType = 'work' | 'difficulty' | 'participation';
 
 const addressColumn: BoardColumn<ParticipantRow> = {
   key: 'address',
@@ -58,6 +60,16 @@ const participationColumns: BoardColumn<ParticipantRow>[] = [
   }
 ];
 
+const workColumns: BoardColumn<ParticipantRow>[] = [
+  addressColumn,
+  {
+    key: 'total_work',
+    header: 'Work',
+    align: 'right',
+    render: (value) => formatDifficulty(value as number)
+  }
+];
+
 function toRows(data: RoundParticipant[]): ParticipantRow[] {
   return data.map((p, i) => ({
     id: i + 1,
@@ -65,6 +77,7 @@ function toRows(data: RoundParticipant[]): ParticipantRow[] {
     claimed: p.claimed,
     top_diff: p.top_diff,
     blocks_participated: p.blocks_participated,
+    total_work: p.total_work,
     rank: p.rank,
   }));
 }
@@ -73,10 +86,11 @@ export default function RoundsPage() {
   const [rounds, setRounds] = useState<Round[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedRound, setExpandedRound] = useState<number | null>(null);
+  const [workParticipants, setWorkParticipants] = useState<ParticipantRow[]>([]);
   const [diffParticipants, setDiffParticipants] = useState<ParticipantRow[]>([]);
   const [partParticipants, setPartParticipants] = useState<ParticipantRow[]>([]);
   const [participantsLoading, setParticipantsLoading] = useState(false);
-  const [mobileTab, setMobileTab] = useState<LeaderboardType>('difficulty');
+  const [mobileTab, setMobileTab] = useState<LeaderboardType>('work');
   const latestRequest = useRef(0);
   const expandedStatus = rounds.find(r => r.block_height === expandedRound)?.participant_status;
   const prevStatusRef = useRef(expandedStatus);
@@ -112,26 +126,31 @@ export default function RoundsPage() {
     latestRequest.current = requestId;
     setParticipantsLoading(true);
     try {
-      const [diffRes, partRes] = await Promise.all([
+      const [workRes, diffRes, partRes] = await Promise.all([
+        fetch(`/api/rounds/${blockHeight}?type=work&limit=99`),
         fetch(`/api/rounds/${blockHeight}?type=difficulty&limit=99`),
         fetch(`/api/rounds/${blockHeight}?type=participation&limit=99`),
       ]);
       if (latestRequest.current !== requestId) return;
-      if (diffRes.status === 202 || partRes.status === 202) {
+      if (workRes.status === 202 || diffRes.status === 202 || partRes.status === 202) {
+        setWorkParticipants([]);
         setDiffParticipants([]);
         setPartParticipants([]);
         return;
       }
-      if (!diffRes.ok || !partRes.ok) throw new Error('Failed to fetch participants');
-      const [diffData, partData]: [RoundParticipant[], RoundParticipant[]] = await Promise.all([
+      if (!workRes.ok || !diffRes.ok || !partRes.ok) throw new Error('Failed to fetch participants');
+      const [workData, diffData, partData]: [RoundParticipant[], RoundParticipant[], RoundParticipant[]] = await Promise.all([
+        workRes.json(),
         diffRes.json(),
         partRes.json(),
       ]);
+      setWorkParticipants(toRows(workData));
       setDiffParticipants(toRows(diffData));
       setPartParticipants(toRows(partData));
     } catch (error) {
       if (latestRequest.current !== requestId) return;
       console.error('Error fetching participants:', error);
+      setWorkParticipants([]);
       setDiffParticipants([]);
       setPartParticipants([]);
     } finally {
@@ -159,6 +178,7 @@ export default function RoundsPage() {
   const toggleRound = (blockHeight: number) => {
     if (expandedRound === blockHeight) {
       setExpandedRound(null);
+      setWorkParticipants([]);
       setDiffParticipants([]);
       setPartParticipants([]);
     } else {
@@ -247,38 +267,41 @@ export default function RoundsPage() {
                     <>
                       {/* Mobile: tabs */}
                       <div className="flex space-x-2 mb-4 md:hidden">
-                        <button
-                          onClick={() => setMobileTab('difficulty')}
-                          className={`px-3 py-1 transition-colors cursor-pointer ${
-                            mobileTab === 'difficulty'
-                              ? 'bg-foreground text-background'
-                              : 'bg-secondary text-foreground/80 hover:bg-primary-hover hover:text-foreground'
-                          }`}
-                        >
-                          Difficulty
-                        </button>
-                        <button
-                          onClick={() => setMobileTab('participation')}
-                          className={`px-3 py-1 transition-colors cursor-pointer ${
-                            mobileTab === 'participation'
-                              ? 'bg-foreground text-background'
-                              : 'bg-secondary text-foreground/80 hover:bg-primary-hover hover:text-foreground'
-                          }`}
-                        >
-                          Participation
-                        </button>
+                        {([
+                          ['work', 'Work'],
+                          ['difficulty', 'Difficulty'],
+                          ['participation', 'Participation'],
+                        ] as [LeaderboardType, string][]).map(([tab, label]) => (
+                          <button
+                            key={tab}
+                            onClick={() => setMobileTab(tab)}
+                            className={`px-3 py-1 transition-colors cursor-pointer ${
+                              mobileTab === tab
+                                ? 'bg-foreground text-background'
+                                : 'bg-secondary text-foreground/80 hover:bg-primary-hover hover:text-foreground'
+                            }`}
+                          >
+                            {label}
+                          </button>
+                        ))}
                       </div>
                       {/* Mobile: single table based on active tab */}
                       <div className="md:hidden">
                         <Board
-                          title={mobileTab === 'difficulty' ? 'Top Difficulties' : 'Most Participation'}
-                          data={mobileTab === 'difficulty' ? diffParticipants : partParticipants}
-                          columns={mobileTab === 'difficulty' ? diffColumns : participationColumns}
+                          title={mobileTab === 'work' ? 'Most Work' : mobileTab === 'difficulty' ? 'Top Difficulties' : 'Most Participation'}
+                          data={mobileTab === 'work' ? workParticipants : mobileTab === 'difficulty' ? diffParticipants : partParticipants}
+                          columns={mobileTab === 'work' ? workColumns : mobileTab === 'difficulty' ? diffColumns : participationColumns}
                           isLoading={participantsLoading}
                         />
                       </div>
                       {/* Desktop: side by side */}
-                      <div className="hidden md:grid md:grid-cols-2 gap-4">
+                      <div className="hidden md:grid md:grid-cols-3 gap-4">
+                        <Board
+                          title="Most Work"
+                          data={workParticipants}
+                          columns={workColumns}
+                          isLoading={participantsLoading}
+                        />
                         <Board
                           title="Top Difficulties"
                           data={diffParticipants}

--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -82,13 +82,23 @@ function toRows(data: RoundParticipant[]): ParticipantRow[] {
   }));
 }
 
+const LEADERBOARDS: { type: LeaderboardType; label: string; title: string; columns: BoardColumn<ParticipantRow>[] }[] = [
+  { type: 'work', label: 'Work', title: 'Most Work', columns: workColumns },
+  { type: 'difficulty', label: 'Difficulty', title: 'Top Difficulties', columns: diffColumns },
+  { type: 'participation', label: 'Participation', title: 'Most Participation', columns: participationColumns },
+];
+
+const emptyParticipants: Record<LeaderboardType, ParticipantRow[]> = {
+  work: [],
+  difficulty: [],
+  participation: [],
+};
+
 export default function RoundsPage() {
   const [rounds, setRounds] = useState<Round[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedRound, setExpandedRound] = useState<number | null>(null);
-  const [workParticipants, setWorkParticipants] = useState<ParticipantRow[]>([]);
-  const [diffParticipants, setDiffParticipants] = useState<ParticipantRow[]>([]);
-  const [partParticipants, setPartParticipants] = useState<ParticipantRow[]>([]);
+  const [participants, setParticipants] = useState<Record<LeaderboardType, ParticipantRow[]>>(emptyParticipants);
   const [participantsLoading, setParticipantsLoading] = useState(false);
   const [mobileTab, setMobileTab] = useState<LeaderboardType>('work');
   const latestRequest = useRef(0);
@@ -126,33 +136,23 @@ export default function RoundsPage() {
     latestRequest.current = requestId;
     setParticipantsLoading(true);
     try {
-      const [workRes, diffRes, partRes] = await Promise.all([
-        fetch(`/api/rounds/${blockHeight}?type=work&limit=99`),
-        fetch(`/api/rounds/${blockHeight}?type=difficulty&limit=99`),
-        fetch(`/api/rounds/${blockHeight}?type=participation&limit=99`),
-      ]);
+      const responses = await Promise.all(
+        LEADERBOARDS.map(lb => fetch(`/api/rounds/${blockHeight}?type=${lb.type}&limit=99`))
+      );
       if (latestRequest.current !== requestId) return;
-      if (workRes.status === 202 || diffRes.status === 202 || partRes.status === 202) {
-        setWorkParticipants([]);
-        setDiffParticipants([]);
-        setPartParticipants([]);
+      if (responses.some(r => r.status === 202)) {
+        setParticipants(emptyParticipants);
         return;
       }
-      if (!workRes.ok || !diffRes.ok || !partRes.ok) throw new Error('Failed to fetch participants');
-      const [workData, diffData, partData]: [RoundParticipant[], RoundParticipant[], RoundParticipant[]] = await Promise.all([
-        workRes.json(),
-        diffRes.json(),
-        partRes.json(),
-      ]);
-      setWorkParticipants(toRows(workData));
-      setDiffParticipants(toRows(diffData));
-      setPartParticipants(toRows(partData));
+      if (responses.some(r => !r.ok)) throw new Error('Failed to fetch participants');
+      const data: RoundParticipant[][] = await Promise.all(responses.map(r => r.json()));
+      setParticipants(
+        Object.fromEntries(LEADERBOARDS.map((lb, i) => [lb.type, toRows(data[i])])) as Record<LeaderboardType, ParticipantRow[]>
+      );
     } catch (error) {
       if (latestRequest.current !== requestId) return;
       console.error('Error fetching participants:', error);
-      setWorkParticipants([]);
-      setDiffParticipants([]);
-      setPartParticipants([]);
+      setParticipants(emptyParticipants);
     } finally {
       if (latestRequest.current === requestId) {
         setParticipantsLoading(false);
@@ -178,9 +178,7 @@ export default function RoundsPage() {
   const toggleRound = (blockHeight: number) => {
     if (expandedRound === blockHeight) {
       setExpandedRound(null);
-      setWorkParticipants([]);
-      setDiffParticipants([]);
-      setPartParticipants([]);
+      setParticipants(emptyParticipants);
     } else {
       setExpandedRound(blockHeight);
       fetchParticipants(blockHeight);
@@ -267,53 +265,43 @@ export default function RoundsPage() {
                     <>
                       {/* Mobile: tabs */}
                       <div className="flex space-x-2 mb-4 md:hidden">
-                        {([
-                          ['work', 'Work'],
-                          ['difficulty', 'Difficulty'],
-                          ['participation', 'Participation'],
-                        ] as [LeaderboardType, string][]).map(([tab, label]) => (
+                        {LEADERBOARDS.map(lb => (
                           <button
-                            key={tab}
-                            onClick={() => setMobileTab(tab)}
+                            key={lb.type}
+                            onClick={() => setMobileTab(lb.type)}
                             className={`px-3 py-1 transition-colors cursor-pointer ${
-                              mobileTab === tab
+                              mobileTab === lb.type
                                 ? 'bg-foreground text-background'
                                 : 'bg-secondary text-foreground/80 hover:bg-primary-hover hover:text-foreground'
                             }`}
                           >
-                            {label}
+                            {lb.label}
                           </button>
                         ))}
                       </div>
                       {/* Mobile: single table based on active tab */}
                       <div className="md:hidden">
-                        <Board
-                          title={mobileTab === 'work' ? 'Most Work' : mobileTab === 'difficulty' ? 'Top Difficulties' : 'Most Participation'}
-                          data={mobileTab === 'work' ? workParticipants : mobileTab === 'difficulty' ? diffParticipants : partParticipants}
-                          columns={mobileTab === 'work' ? workColumns : mobileTab === 'difficulty' ? diffColumns : participationColumns}
-                          isLoading={participantsLoading}
-                        />
+                        {LEADERBOARDS.filter(lb => lb.type === mobileTab).map(lb => (
+                          <Board
+                            key={lb.type}
+                            title={lb.title}
+                            data={participants[lb.type]}
+                            columns={lb.columns}
+                            isLoading={participantsLoading}
+                          />
+                        ))}
                       </div>
                       {/* Desktop: side by side */}
                       <div className="hidden md:grid md:grid-cols-3 gap-4">
-                        <Board
-                          title="Most Work"
-                          data={workParticipants}
-                          columns={workColumns}
-                          isLoading={participantsLoading}
-                        />
-                        <Board
-                          title="Top Difficulties"
-                          data={diffParticipants}
-                          columns={diffColumns}
-                          isLoading={participantsLoading}
-                        />
-                        <Board
-                          title="Most Participation"
-                          data={partParticipants}
-                          columns={participationColumns}
-                          isLoading={participantsLoading}
-                        />
+                        {LEADERBOARDS.map(lb => (
+                          <Board
+                            key={lb.type}
+                            title={lb.title}
+                            data={participants[lb.type]}
+                            columns={lb.columns}
+                            isLoading={participantsLoading}
+                          />
+                        ))}
                       </div>
                     </>
                   )}

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -361,9 +361,11 @@ export default function UserDashboard() {
       block_height: CURRENT_ROUND_BLOCK,
       rank: roundsData.current_round.rank,
       blocks_rank: roundsData.current_round.blocks_rank,
+      work_rank: roundsData.current_round.work_rank,
       total_participants: roundsData.current_round.total_participants,
       top_diff: roundsData.current_round.top_diff,
       blocks_participated: roundsData.current_round.blocks_participated,
+      total_work: roundsData.current_round.total_work,
       is_winner: false,
     }] : []),
     ...(roundsData?.history ?? []),
@@ -864,6 +866,16 @@ export default function UserDashboard() {
                                   ),
                             },
                             {
+                              key: 'work_rank',
+                              header: 'Work Rank',
+                              render: (_, item) => `${item.work_rank} / ${item.total_participants}`,
+                            },
+                            {
+                              key: 'total_work',
+                              header: 'Work',
+                              render: (value) => formatDifficulty(value as number),
+                            },
+                            {
                               key: 'rank',
                               header: 'Diff Rank',
                               render: (_, item) => `${item.rank} / ${item.total_participants}`,
@@ -909,6 +921,14 @@ export default function UserDashboard() {
                               )}
                             </div>
                             <div className="grid grid-cols-2 gap-2 text-sm">
+                              <div>
+                                <p className="text-foreground/60">Work Rank</p>
+                                <p className="font-medium">{round.work_rank} / {round.total_participants}</p>
+                              </div>
+                              <div>
+                                <p className="text-foreground/60">Work</p>
+                                <p className="font-medium">{formatDifficulty(round.total_work)}</p>
+                              </div>
                               <div>
                                 <p className="text-foreground/60">Diff Rank</p>
                                 <p className="font-medium">{round.rank} / {round.total_participants}</p>

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -17,6 +17,9 @@ export type PoolStats = {
   hashrate: number;
   users: number;
   workers: number;
+  // Counted cumulative accepted work (sum of share difficulty) since the last block.
+  // null when no current-round data has been collected yet.
+  workSinceLastBlock: number | null;
 }
 
 // Helper function to create a delay

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -17,8 +17,7 @@ export type PoolStats = {
   hashrate: number;
   users: number;
   workers: number;
-  // Counted cumulative accepted work (sum of share difficulty) since the last block.
-  // null when no current-round data has been collected yet.
+  // Counted work since the last block; null until the collector has data.
   workSinceLastBlock: number | null;
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -211,15 +211,21 @@ function initializeTables() {
       username TEXT NOT NULL,
       top_diff REAL NOT NULL DEFAULT 0,
       blocks_participated INTEGER NOT NULL DEFAULT 0,
+      total_work REAL NOT NULL DEFAULT 0,
       PRIMARY KEY (block_height, username)
     )
   `);
+
+  // total_work = cumulative accepted share difficulty (work) per user per round.
+  addColumnIfNotExists(db, `ALTER TABLE round_participants ADD COLUMN total_work REAL NOT NULL DEFAULT 0`);
 
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_round_participants_diff
       ON round_participants(block_height, top_diff DESC);
     CREATE INDEX IF NOT EXISTS idx_round_participants_blocks
       ON round_participants(block_height, blocks_participated DESC);
+    CREATE INDEX IF NOT EXISTS idx_round_participants_work
+      ON round_participants(block_height, total_work DESC);
     CREATE INDEX IF NOT EXISTS idx_round_participants_username
       ON round_participants(username, block_height DESC);
   `);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -217,7 +217,18 @@ function initializeTables() {
   `);
 
   // total_work = cumulative accepted share difficulty (work) per user per round.
+  const hadTotalWork = (db.prepare(`PRAGMA table_info(round_participants)`).all() as { name: string }[])
+    .some(column => column.name === 'total_work');
   addColumnIfNotExists(db, `ALTER TABLE round_participants ADD COLUMN total_work REAL NOT NULL DEFAULT 0`);
+
+  // One-time backfill: rounds cached as 'complete' before this column existed have
+  // total_work = 0 for every participant, which the UI would otherwise treat as
+  // real work. Re-mark them for participant refetch so the collector repopulates
+  // real work from the backend. Pool rounds are infrequent, so this is a small,
+  // one-time set of refetches (and re-runs idempotently if it ever repeats).
+  if (!hadTotalWork) {
+    db.prepare(`UPDATE rounds SET participant_status = 'pending' WHERE participant_status = 'complete'`).run();
+  }
 
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_round_participants_diff

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -216,16 +216,12 @@ function initializeTables() {
     )
   `);
 
-  // total_work = cumulative accepted share difficulty (work) per user per round.
   const hadTotalWork = (db.prepare(`PRAGMA table_info(round_participants)`).all() as { name: string }[])
     .some(column => column.name === 'total_work');
   addColumnIfNotExists(db, `ALTER TABLE round_participants ADD COLUMN total_work REAL NOT NULL DEFAULT 0`);
 
-  // One-time backfill: rounds cached as 'complete' before this column existed have
-  // total_work = 0 for every participant, which the UI would otherwise treat as
-  // real work. Re-mark them for participant refetch so the collector repopulates
-  // real work from the backend. Pool rounds are infrequent, so this is a small,
-  // one-time set of refetches (and re-runs idempotently if it ever repeats).
+  // Rounds completed before total_work existed default to 0, which the UI would
+  // treat as real. Re-mark them so the collector refetches real work once.
   if (!hadTotalWork) {
     db.prepare(`UPDATE rounds SET participant_status = 'pending' WHERE participant_status = 'complete'`).run();
   }

--- a/lib/rounds-collector.ts
+++ b/lib/rounds-collector.ts
@@ -15,6 +15,7 @@ interface RoundParticipant {
   username: string;
   blocks_participated: number;
   top_diff: number;
+  total_work?: number;
 }
 
 // Configuration
@@ -237,12 +238,12 @@ export async function collectCurrentRound(): Promise<void> {
       db.prepare('DELETE FROM round_participants WHERE block_height = 0').run();
 
       const insert = db.prepare(`
-        INSERT INTO round_participants (block_height, username, top_diff, blocks_participated)
-        VALUES (0, ?, ?, ?)
+        INSERT INTO round_participants (block_height, username, top_diff, blocks_participated, total_work)
+        VALUES (0, ?, ?, ?, ?)
       `);
 
       for (const p of participants) {
-        insert.run(p.username, p.top_diff, p.blocks_participated);
+        insert.run(p.username, p.top_diff, p.blocks_participated, p.total_work ?? 0);
       }
     })();
 
@@ -296,12 +297,12 @@ export async function fetchPendingRoundParticipants(): Promise<void> {
           db.prepare('DELETE FROM round_participants WHERE block_height = ?').run(blockHeight);
 
           const insert = db.prepare(`
-            INSERT INTO round_participants (block_height, username, top_diff, blocks_participated)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO round_participants (block_height, username, top_diff, blocks_participated, total_work)
+            VALUES (?, ?, ?, ?, ?)
           `);
 
           for (const p of participants) {
-            insert.run(blockHeight, p.username, p.top_diff, p.blocks_participated);
+            insert.run(blockHeight, p.username, p.top_diff, p.blocks_participated, p.total_work ?? 0);
           }
 
           db.prepare('UPDATE rounds SET participant_status = ?, error_message = NULL WHERE block_height = ?')

--- a/lib/rounds-collector.ts
+++ b/lib/rounds-collector.ts
@@ -377,6 +377,12 @@ export function triggerRoundsSync(): void {
   syncRounds()
     .then(newRounds => {
       if (newRounds > 0) {
+        // A new block was found, so the current round just reset. Refresh the
+        // block_height=0 rows now instead of waiting for the 10-minute cron —
+        // otherwise "work since last block" keeps reporting the previous round.
+        collectCurrentRound().catch(err =>
+          console.error('Error collecting current round after new round:', err)
+        );
         // New round detected — fetch participants in background
         fetchPendingRoundParticipants().catch(err =>
           console.error('Error fetching pending round participants:', err)


### PR DESCRIPTION
## Summary

Surfaces **counted** work per round and pool-wide work since the last block, replacing the need to *estimate* work from hashrate samples. This is the frontend half of parasitepool/para#486, which adds `total_work` (counted `SUM(diff)`) to the round-participation API.

This is also a cleaner alternative to #283: instead of integrating `hashrate15m × time_gap / 2³²` into checkpoint tables, it reads the real counted work the backend already tracks for payouts.

> Depends on parasitepool/para#486 — until that backend ships, `total_work` arrives as `0` (handled gracefully: the dashboard card shows `-`, columns show `0`).

## What changed

**Data**
- `round_participants` gains a `total_work` column (with `addColumnIfNotExists` migration + a sort index), ingested by the rounds collector from `/rounds/current` and `/rounds/{height}`.
- `/api/pool-stats` returns `workSinceLastBlock` = `SUM(total_work)` over the current round (block_height = 0). Returns `null` (shown as `-`) until data is collected, rather than a misleading `0`. DB read is wrapped so it never breaks the rest of the pool-stats response.

**UI / UX**
- **Rounds page:** new **Most Work** leaderboard — the headline per-user contribution metric — as a third mobile tab and a third desktop board (`md:grid-cols-3`). Work is the default-selected tab.
- **User page:** rounds table/cards gain **Work** and **Work Rank** (with a `RANK()`-based work rank per round), placed as the primary metric pair.
- **Dashboard:** new **"Work Since Last Block"** stat card (pickaxe icon + explanatory tooltip). The stat-card grid was reflowed from a 6-wide flex layout to a CSS grid (`grid-cols-2 md:grid-cols-4 lg:grid-cols-7`) so 7 cards stay clean and responsive.

## Testing

- `tsc --noEmit`, `eslint`, and `next build` all pass.
