### PR TITLE
fix: hashrate chart zoom resetting on data refresh

### DIFF
--- a/app/components/HashrateChart.tsx
+++ b/app/components/HashrateChart.tsx
@@ -129,6 +129,71 @@ export default function HashrateChart({
     onToggle();
   };
 
+  // Scale the hashrate y-axis to the visible zoom window (merged so dataZoom is left alone).
+  const applyYAxisScale = useCallback((chart: echarts.ECharts, startPercent: number, endPercent: number) => {
+    const currentOption = chart.getOption() as {
+      series?: Array<{ data?: number[]; name?: string; yAxisIndex?: number }>;
+      xAxis?: Array<{ data?: string[] }>;
+    };
+    const currentSeries = currentOption.series;
+    const currentXAxisData = currentOption.xAxis?.[0]?.data;
+
+    if (!currentSeries || !currentSeries.length || !currentXAxisData || !currentXAxisData.length) {
+      return;
+    }
+
+    // If fully zoomed out, revert to automatic scaling
+    if (startPercent <= 0 && endPercent >= 100) {
+      chart.setOption({
+        yAxis: {
+          min: null,
+          max: null,
+        },
+      }, false);
+      return;
+    }
+
+    // Calculate the actual data indices for the zoom range
+    const totalDataLength = currentXAxisData.length;
+    const startIndex = Math.floor((startPercent / 100) * totalDataLength);
+    const endIndex = Math.min(Math.ceil((endPercent / 100) * totalDataLength), totalDataLength - 1);
+
+    // Find min and max values within the visible range for all series
+    let visibleMin = Infinity;
+    let visibleMax = -Infinity;
+
+    currentSeries.forEach((series) => {
+      // Skip Best Diff (secondary axis, difficulty values) so it doesn't blow out the max
+      if (series.yAxisIndex != null && series.yAxisIndex !== 0) return;
+      if (!series.data) return;
+
+      for (let i = startIndex; i <= endIndex && i < series.data.length; i++) {
+        const value = series.data[i];
+        if (value !== null && value !== undefined && !isNaN(value)) {
+          visibleMin = Math.min(visibleMin, value);
+          visibleMax = Math.max(visibleMax, value);
+        }
+      }
+    });
+
+    // Only update if we found valid data
+    if (visibleMin !== Infinity && visibleMax !== -Infinity) {
+      // Add some padding (10% on each side for better visibility)
+      const range = visibleMax - visibleMin;
+      const padding = Math.max(range * 0.1, range === 0 ? visibleMax * 0.1 : 0);
+      // const adjustedMin = Math.max(0, visibleMin - padding); // Don't go below 0 for hashrate
+      const adjustedMax = visibleMax + padding;
+
+      // Update y-axis with new range
+      chart.setOption({
+        yAxis: {
+          min: 0, // For hashrate, let's just keep it at 0 for now
+          max: adjustedMax,
+        },
+      }, false);
+    }
+  }, []);
+
   // Build chart options function - memoized to avoid recreating on every render
   const buildChartOptions = useCallback((chartData: typeof data, diffData?: BestDiffPoint[]) => {
     // Get theme colors from CSS variables
@@ -401,84 +466,34 @@ export default function HashrateChart({
       chart = echarts.init(chartRef.current);
       chartInstanceRef.current = chart;
 
-      // Add datazoom event listener for auto-scaling y-axis
-      const handleDataZoom = (params: unknown) => {
-        const dataZoomParams = params as { start: number; end: number; type: string };
-        // Get current data from the chart option instead of using closure data
-        const currentOption = chart!.getOption() as {
-          series?: Array<{ data?: number[]; name?: string }>;
-          xAxis?: Array<{ data?: string[] }>;
+      // Auto-scale y-axis on zoom; read the range from the option (handles batch events)
+      const handleDataZoom = () => {
+        const zoomOption = chart!.getOption() as {
+          dataZoom?: Array<{ start?: number; end?: number }>;
         };
-        const currentSeries = currentOption.series;
-        const currentXAxisData = currentOption.xAxis?.[0]?.data;
-        
-        if (!currentSeries || !currentSeries.length || !currentXAxisData || !currentXAxisData.length) {
-          return;
-        }
-        
-        // Get start and end percentages directly from the event params
-        const startPercent = dataZoomParams.start || 0;
-        const endPercent = dataZoomParams.end || 100;
-        
-        // If fully zoomed out, revert to automatic scaling
-        if (startPercent <= 0 && endPercent >= 100) {
-          chart!.setOption({
-            yAxis: {
-              min: null,
-              max: null
-            }
-          }, false);
-          return;
-        }
-        
-        // Calculate the actual data indices for the zoom range
-        const totalDataLength = currentXAxisData.length;
-        const startIndex = Math.floor((startPercent / 100) * totalDataLength);
-        const endIndex = Math.min(Math.ceil((endPercent / 100) * totalDataLength), totalDataLength - 1);
-        
-        // Find min and max values within the visible range for all series
-        let visibleMin = Infinity;
-        let visibleMax = -Infinity;
-        
-        currentSeries.forEach((series) => {
-          if (!series.data) return;
-          
-          for (let i = startIndex; i <= endIndex && i < series.data.length; i++) {
-            const value = series.data[i];
-            if (value !== null && value !== undefined && !isNaN(value)) {
-              visibleMin = Math.min(visibleMin, value);
-              visibleMax = Math.max(visibleMax, value);
-            }
-          }
-        });
-        
-        // Only update if we found valid data
-        if (visibleMin !== Infinity && visibleMax !== -Infinity) {
-          // Add some padding (10% on each side for better visibility)
-          const range = visibleMax - visibleMin;
-          const padding = Math.max(range * 0.1, range === 0 ? visibleMax * 0.1 : 0);
-          // const adjustedMin = Math.max(0, visibleMin - padding); // Don't go below 0 for hashrate
-          const adjustedMax = visibleMax + padding;
-          
-          // Update y-axis with new range
-          chart!.setOption({
-            yAxis: {
-              min: 0, // For hashrate, let's just keep it at 0 for now
-              max: adjustedMax
-            }
-          }, false);
-        }
+        const startPercent = zoomOption.dataZoom?.[0]?.start ?? 0;
+        const endPercent = zoomOption.dataZoom?.[0]?.end ?? 100;
+        applyYAxisScale(chart!, startPercent, endPercent);
       };
 
       chart.on('datazoom', handleDataZoom);
       isInitializedRef.current = true;
     }
 
-    // Set/update chart options with data
+    // replaceMerge drops the stale series/yAxis/legend but merges everything else, so
+    // dataZoom keeps its range and the zoom survives refreshes (notMerge would reset it).
     if (isInitializedRef.current) {
-      chart.setOption(buildChartOptions(data, bestDiffs), { notMerge: true });
+      chart.setOption(buildChartOptions(data, bestDiffs), { replaceMerge: ['series', 'yAxis', 'legend'] });
+
+      // Re-apply the y-axis fit, which the rebuild reset
+      const zoomOption = chart.getOption() as {
+        dataZoom?: Array<{ start?: number; end?: number }>;
+      };
+      const startPercent = zoomOption.dataZoom?.[0]?.start ?? 0;
+      const endPercent = zoomOption.dataZoom?.[0]?.end ?? 100;
+      applyYAxisScale(chart, startPercent, endPercent);
     }
-  }, [bestDiffs, buildChartOptions, collapsed, data]);
+  }, [applyYAxisScale, bestDiffs, buildChartOptions, collapsed, data]);
 
   useEffect(() => {
     if (!collapsed) {

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -356,6 +356,50 @@ export default function UserDashboard() {
     };
   }, [userId, isValidAddress]);
 
+  // Memoize so the chart only rebuilds when the data actually changes, not on every poll
+  const hashrateChartData = useMemo(() => (
+    historicalData ? {
+      timestamps: historicalData.map(d => {
+        const date = new Date(d.timestamp);
+        return date.toLocaleString("en-US", {
+          year: undefined,
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        });
+      }),
+      rawTimestamps: historicalData.map(d => new Date(d.timestamp).getTime()),
+      series: [
+        {
+          data: historicalData.map(d => d.hashrate),
+          title: "Hashrate",
+        },
+      ],
+    } : undefined
+  ), [historicalData]);
+
+  const hashrateChartBestDiffs = useMemo(() => (
+    userBlockDiffs.length > 0 ? userBlockDiffs
+      .filter(diff => diff.block_timestamp !== null)
+      .map(diff => {
+        const timestampMs = diff.block_timestamp! * 1000;
+        return {
+          timestamp: new Date(timestampMs).toLocaleString("en-US", {
+            year: undefined,
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          }),
+          rawTimestamp: timestampMs,
+          difficulty: diff.difficulty,
+        };
+      }) : undefined
+  ), [userBlockDiffs]);
+
   const allRounds = useMemo(() => [
     ...(roundsData?.current_round ? [{
       block_height: CURRENT_ROUND_BLOCK,
@@ -762,43 +806,8 @@ export default function UserDashboard() {
                 icon={<TrendingUpIcon />}
                 collapsed={collapsedSections.hashrateChart}
                 onToggle={() => toggleCollapsedSection('hashrateChart')}
-                data={historicalData ? {
-                  timestamps: historicalData.map(d => {
-                    const date = new Date(d.timestamp);
-                    return date.toLocaleString("en-US", {
-                      year: undefined,
-                      month: "2-digit",
-                      day: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      hour12: false,
-                    });
-                  }),
-                  rawTimestamps: historicalData.map(d => new Date(d.timestamp).getTime()),
-                  series: [
-                    {
-                      data: historicalData.map(d => d.hashrate),
-                      title: "Hashrate"
-                    }
-                  ]
-                } : undefined}
-                bestDiffs={userBlockDiffs.length > 0 ? userBlockDiffs
-                    .filter(diff => diff.block_timestamp !== null)
-                    .map(diff => {
-                      const timestampMs = diff.block_timestamp! * 1000;
-                      return {
-                        timestamp: new Date(timestampMs).toLocaleString("en-US", {
-                          year: undefined,
-                          month: "2-digit",
-                          day: "2-digit",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          hour12: false,
-                        }),
-                        rawTimestamp: timestampMs,
-                        difficulty: diff.difficulty,
-                      };
-                    }) : undefined}
+                data={hashrateChartData}
+                bestDiffs={hashrateChartBestDiffs}
                 loading={!historicalData}
             />
           </div>


### PR DESCRIPTION
Zoom on the Hashrate & Difficulty chart was snapping back out after a few seconds. The chart rebuilds with `notMerge: true` on every poll, which resets `dataZoom` back to full range.

Switched to `replaceMerge` (series/yAxis/legend) so the Best Diff series/axis still get removed when they're gone, but `dataZoom` keeps its range and the zoom sticks.

While in there:
- y-axis auto-scale now only looks at the hashrate series — a large Best Diff value (secondary axis) could otherwise flatten the line
- memoized the chart props so it's not rebuilding every ~10s