### PR TITLE
fix: guard invalid API params, timestamps, and env-derived batch sizes

### DIFF
--- a/app/api/highest-diff/route.ts
+++ b/app/api/highest-diff/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const limit = Math.min(Math.max(1, parseInt(searchParams.get('limit') || '10', 10)), MAX_LIMIT);
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '10', 10) || 10, 1), MAX_LIMIT);
     const address = searchParams.get('address');
     const type = searchParams.get('type') || 'recent'; // recent, leaderboard, user-diffs
 

--- a/app/api/user/[address]/historical/route.ts
+++ b/app/api/user/[address]/historical/route.ts
@@ -67,14 +67,8 @@ export async function GET(
       case '1h':
         hashrateColumn = 'hashrate1hr';
         break;
-      case '1d':
-        hashrateColumn = 'hashrate1d';
-        break;
-      case '7d':
-        hashrateColumn = 'hashrate7d';
-        break;
       default:
-        hashrateColumn = 'hashrate5m'; // Default to 5m
+        hashrateColumn = 'hashrate5m'; // Default to 5m (covers 15m/30m)
     }
     
     // Calculate the time range based on the period

--- a/app/api/user/[address]/route.ts
+++ b/app/api/user/[address]/route.ts
@@ -117,6 +117,9 @@ function processWorkerData(workers: WorkerData[]): ProcessedWorkerData[] {
 }
 
 function calculateUptime(authorisedTimestamp: number): string {
+  // 0 means the user was never authorised; measuring from the epoch would report decades.
+  if (!Number.isFinite(authorisedTimestamp) || authorisedTimestamp <= 0) return 'N/A';
+
   const now = Math.floor(Date.now() / 1000); // Current time in Unix timestamp
   const uptimeSeconds = now - authorisedTimestamp;
 

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -63,6 +63,10 @@ export function formatAddress(address: string): string {
 }
 
 export function formatRelativeTime(timestamp: number): string {
+  // 0 is the pool's "never submitted" sentinel; callers may also pass NaN from a
+  // missing lastshare. Both would otherwise render as a date near the epoch.
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'Never';
+
   const now = new Date();
   const date = new Date(timestamp * 1000); // Convert Unix timestamp to milliseconds
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse an environment variable as a positive integer.
+ *
+ * Falls back for anything that isn't a finite integer > 0. Batch sizes and loop
+ * strides are the main callers: a `0` stride loops forever and a `NaN` stride
+ * skips the loop body entirely, so neither may ever reach the caller.
+ */
+export function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.warn(`Ignoring invalid value "${raw}" for positive integer, using ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}

--- a/lib/pool-stats-collector.ts
+++ b/lib/pool-stats-collector.ts
@@ -1,5 +1,6 @@
 import cron from 'node-cron';
 import { getDb } from './db';
+import { parsePositiveInt } from './env';
 import { fetch, HttpError, isRetryableError } from './http-client';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
 
@@ -45,11 +46,11 @@ let isAccountJobRunning = false;
 
 // Configuration constants
 const CONFIG = {
-  MAX_FAILED_ATTEMPTS: parseInt(process.env.MAX_FAILED_ATTEMPTS || '10'),
-  BATCH_SIZE: parseInt(process.env.USER_BATCH_SIZE || '500'), // Process users in batches (concurrent API requests)
-  FAILED_USER_BACKOFF_MINUTES: parseInt(process.env.FAILED_USER_BACKOFF_MINUTES || '2'), // Don't retry failed users for 2 minutes
+  MAX_FAILED_ATTEMPTS: parsePositiveInt(process.env.MAX_FAILED_ATTEMPTS, 10),
+  BATCH_SIZE: parsePositiveInt(process.env.USER_BATCH_SIZE, 500), // Process users in batches (concurrent API requests)
+  FAILED_USER_BACKOFF_MINUTES: parsePositiveInt(process.env.FAILED_USER_BACKOFF_MINUTES, 2), // Don't retry failed users for 2 minutes
   AUTO_DISCOVER_USERS: process.env.AUTO_DISCOVER_USERS !== 'false', // Enable automatic user discovery (default: true)
-  AUTO_DISCOVER_BATCH_LIMIT: parseInt(process.env.AUTO_DISCOVER_BATCH_LIMIT || '100'), // Max new users to add per cycle
+  AUTO_DISCOVER_BATCH_LIMIT: parsePositiveInt(process.env.AUTO_DISCOVER_BATCH_LIMIT, 100), // Max new users to add per cycle
   SQL_BATCH_SIZE: 500, // Max parameters per SQL statement (SQLite limit is 999)
 } as const;
 

--- a/lib/refinery-badge-sync.ts
+++ b/lib/refinery-badge-sync.ts
@@ -1,7 +1,8 @@
 import { getDb } from './db';
+import { parsePositiveInt } from './env';
 import type { OrderSummary } from '../app/api/router/types';
 
-const BATCH_SIZE = parseInt(process.env.REFINERY_BADGE_BATCH_SIZE || '50');
+const BATCH_SIZE = parsePositiveInt(process.env.REFINERY_BADGE_BATCH_SIZE, 50);
 
 export async function syncRefineryBadges() {
   const routerBase = process.env.ROUTER_API_URL;


### PR DESCRIPTION
Hardens a few validations found in a review:

- **highest-diff API**: a non-numeric `limit` param previously produced `NaN` and reached better-sqlite3 as an invalid bind (500 error); it now falls back to the default of 10.
- **Relative time / uptime formatting**: `formatRelativeTime` and `calculateUptime` now render "Never" / "N/A" for the `0` sentinel (never submitted / never authorised) and `NaN`, instead of an epoch-relative value like "56y ago".
- **User historical API**: removed unreachable `1d`/`7d` switch cases — interval validation only permits `m`/`h` units.
- **Env-derived batch sizes**: new `parsePositiveInt` helper in `lib/env.ts` guards all five env-derived integers (batch sizes, retry limits, backoff). Invalid values previously broke collector loops: a `0` stride loops forever, a `NaN` stride silently processes zero users.