### PR TITLE
Fix inconsistent Total Work units (B vs G)

### DIFF
--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -145,15 +145,17 @@ export function formatExpectedBlockTime(poolHashrate: number | string | undefine
 }
 
 /**
- * Formats a large number with compact suffixes (K, M, B, T)
- * e.g. 1234 -> 1.23K, 1234567890 -> 1.23B
+ * Formats a large number with compact SI suffixes (K, M, G, T)
+ * e.g. 1234 -> 1.23K, 1234567890 -> 1.23G
+ * Uses the same SI unit family as formatDifficulty so accumulated work/share
+ * values stay consistent with difficulty and hashrate displays.
  * Supports bigint for very large numbers
  */
 export function formatCompactNumber(value: bigint | number): string {
   const num = typeof value === 'bigint' ? Number(value) : value;
   if (num === 0) return '0';
 
-  const suffixes = ['', 'K', 'M', 'B', 'T', 'Q'];
+  const suffixes = ['', 'K', 'M', 'G', 'T', 'P'];
   const absNum = Math.abs(num);
 
   if (absNum < 1000) {


### PR DESCRIPTION
The Total Work stat card shows values like `1.23B`, while per-round Work, Top Diff, and everything else show `1.23G`. B and G are the same magnitude (10^9), so the same work value looks inconsistent — confusing next to each other in a round card.

This points the Total Work card at the same SI suffixes (K/M/G/T) the rest of the app uses. Only `formatCompactNumber` changes, which is used solely by the Total Work card.
