### PR TITLE
Show QR code for Refinery deposits

### DIFF
--- a/app/components/modals/CreateOrderModal.tsx
+++ b/app/components/modals/CreateOrderModal.tsx
@@ -151,7 +151,7 @@ export default function CreateOrderModal({ isOpen, onClose, onCreated, address, 
       onClick={handleBackdropClick}
     >
       <div
-        className="bg-background border border-foreground p-6 max-w-2xl w-full mx-4 shadow-xl"
+        className="bg-background border border-foreground p-6 max-w-2xl w-full mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-start mb-4">
@@ -287,7 +287,7 @@ export default function CreateOrderModal({ isOpen, onClose, onCreated, address, 
         {view === 'payment' && orderData && (
           <div className="space-y-4">
             <div className="flex flex-col items-center gap-2">
-              <div className="bg-white p-3 rounded-md">
+              <div className="bg-white p-6 rounded-md">
                 <QRCode
                   value={orderData.payment_address}
                   size={160}

--- a/app/components/modals/CreateOrderModal.tsx
+++ b/app/components/modals/CreateOrderModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { request, RpcErrorCode } from '@sats-connect/core';
+import QRCode from 'react-qr-code';
 import { useWallet } from '@/app/hooks/useWallet';
 import { InfoIcon, CopyIcon, CheckIcon } from '@/app/components/icons';
 import type { OrderResponse } from '@/app/api/router/types';
@@ -285,6 +286,18 @@ export default function CreateOrderModal({ isOpen, onClose, onCreated, address, 
 
         {view === 'payment' && orderData && (
           <div className="space-y-4">
+            <div className="flex flex-col items-center gap-2">
+              <div className="bg-white p-3 rounded-md">
+                <QRCode
+                  value={orderData.payment_address}
+                  size={160}
+                  bgColor="#ffffff"
+                  fgColor="#000000"
+                  level="M"
+                />
+              </div>
+              <p className="text-[10px] text-foreground/40">Scan to get the deposit address</p>
+            </div>
             <div>
               <h3 className="text-sm font-medium text-accent-2 mb-2">Payment Address</h3>
               <div className="bg-secondary p-3 border border-border flex items-center justify-between gap-2">

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pg": "8.22.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-qr-code": "^2.2.0",
+    "react-qr-code": "2.2.0",
     "reflect-metadata": "0.2.2",
     "sharp": "0.35.3",
     "undici": "^8.7.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pg": "8.22.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "react-qr-code": "^2.2.0",
     "reflect-metadata": "0.2.2",
     "sharp": "0.35.3",
     "undici": "^8.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-qr-code:
-        specifier: ^2.2.0
+        specifier: 2.2.0
         version: 2.2.0(react@19.2.7)
       reflect-metadata:
         specifier: 0.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-qr-code:
+        specifier: ^2.2.0
+        version: 2.2.0(react@19.2.7)
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
@@ -2332,6 +2335,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode-generator@2.0.4:
+    resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2346,6 +2352,11 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-qr-code@2.2.0:
+    resolution: {integrity: sha512-e5nS0UUN22K3Nf8KBRUzemfdJ6OmnN5w+kbnj1lvJaol9RyVRFeGl05bCkxSN2ZegbLxjjYjX1+mmAoX9+fAhw==}
+    peerDependencies:
+      react: '*'
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -4954,6 +4965,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qrcode-generator@2.0.4: {}
+
   queue-microtask@1.2.3: {}
 
   rc@1.2.8:
@@ -4969,6 +4982,12 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-qr-code@2.2.0(react@19.2.7):
+    dependencies:
+      prop-types: 15.8.1
+      qrcode-generator: 2.0.4
+      react: 19.2.7
 
   react@19.2.7: {}
 


### PR DESCRIPTION
Adds a QR code to the Refinery payment view so the deposit address can be scanned instead of copied manually.

Also keeps the payment modal usable on shorter screens and gives the QR enough white space to scan reliably.

Tested locally at mobile and desktop sizes. Lint, TypeScript, and the production build pass.