### PR TITLE
Return current round work in pool stats

### DIFF
--- a/app/api/pool-stats/route.ts
+++ b/app/api/pool-stats/route.ts
@@ -13,7 +13,6 @@ interface AggregatorPoolData {
 
 // Counted work (sum of accepted share difficulty) for the current round, from
 // the locally-cached per-participant totals.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getWorkSinceLastBlock(): number | null {
   try {
     const row = getDb()
@@ -81,7 +80,7 @@ export async function GET() {
       hashrate: parseHashrate(hashrateData.hashrate5m),
       users: statsData.Users,
       workers: statsData.Workers,
-      workSinceLastBlock: 0, // TODO: getWorkSinceLastBlock(),
+      workSinceLastBlock: getWorkSinceLastBlock(),
     };
     
     return NextResponse.json(poolStats);


### PR DESCRIPTION
/api/pool-stats currently hardcodes workSinceLastBlock to 0, even though the SUM(total_work) helper is already there.

This enables the helper so the API returns the pool's actual total work for the current round. It returns null if current-round data isn't available yet.

Lint, TypeScript, and the production build pass.