### PR TITLE
Harden public endpoints and dependency versions

### DIFF
--- a/app/api/account/[address]/route.ts
+++ b/app/api/account/[address]/route.ts
@@ -107,7 +107,11 @@ export async function GET(
       ...(lightningTokenExpired && { lightningTokenExpired: true }),
     };
 
-    return NextResponse.json(combinedResponse);
+    return NextResponse.json(combinedResponse, {
+      // Personalized by the X-Lightning-Token header — never let a shared
+      // cache serve one user's wallet data to another.
+      headers: { 'Cache-Control': 'private, no-store' },
+    });
   } catch (error) {
     console.error("Error in account endpoint:", error instanceof Error ? error.message : 'Unknown error');
     return NextResponse.json(

--- a/app/api/account/metadata/route.ts
+++ b/app/api/account/metadata/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { isValidBitcoinAddress } from '@/app/utils/validators';
+import { upstreamErrorResponse } from '@/app/api/lib/upstream-error';
 import type { AccountMetadataUpdate } from '@/app/api/account/types';
 import { getDb } from '@/lib/db';
 
@@ -56,11 +57,7 @@ export async function POST(request: Request) {
     });
 
     if (!response.ok) {
-      const text = await response.text().catch(() => response.statusText);
-      return NextResponse.json(
-        { error: `Failed to update account metadata: ${text || response.statusText}` },
-        { status: response.status }
-      );
+      return upstreamErrorResponse(response, 'Failed to update account metadata', 'Account metadata update failed');
     }
 
     const accountData = await response.json();

--- a/app/api/account/update/route.ts
+++ b/app/api/account/update/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { isValidBitcoinAddress } from '@/app/utils/validators';
+import { upstreamErrorResponse } from '@/app/api/lib/upstream-error';
 import type { AccountUpdate } from '@/app/api/account/types';
 
 export async function POST(request: Request) {
@@ -46,11 +47,7 @@ export async function POST(request: Request) {
     });
 
     if (!response.ok) {
-      const text = await response.text().catch(() => response.statusText);
-      return NextResponse.json(
-        { error: `Failed to update user account: ${text || response.statusText}` },
-        { status: response.status }
-      );
+      return upstreamErrorResponse(response, 'Failed to update user account', 'Account update failed');
     }
 
     const accountData = await response.json();

--- a/app/api/lib/historical.ts
+++ b/app/api/lib/historical.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+
+const INTERVAL_SECONDS: Record<string, number> = {
+  '1m': 60,
+  '5m': 5 * 60,
+  '15m': 15 * 60,
+  '30m': 30 * 60,
+  '1h': 60 * 60,
+};
+
+const CACHE_DURATION_SECONDS: Record<string, number> = {
+  '1m': 60,
+  '5m': 300,
+  '15m': 900,
+  '30m': 300,
+  '1h': 3600,
+};
+
+export interface HistoricalRange {
+  interval: string;
+  intervalSeconds: number;
+  cacheDuration: number;
+  startTime: number;
+  now: number;
+}
+
+function badRequest(message: string): NextResponse {
+  return new NextResponse(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+}
+
+/**
+ * Parse and validate the shared `period`/`interval` query parameters used by
+ * the historical stats endpoints. Returns either a ready-to-send 400 response
+ * or the validated time range and bucketing parameters.
+ */
+export function parseHistoricalParams(
+  searchParams: URLSearchParams
+): { error: NextResponse } | { range: HistoricalRange } {
+  const interval = searchParams.get('interval') || '5m';
+  const intervalSeconds = INTERVAL_SECONDS[interval];
+
+  if (!intervalSeconds) {
+    return { error: badRequest("Interval must be one of: '1m', '5m', '15m', '30m', '1h'") };
+  }
+
+  const period = searchParams.get('period') || '24h';
+  const periodMatch = period.match(/^([1-9]\d*)([dh])$/);
+  if (!periodMatch) {
+    return { error: badRequest("Period must be a positive value (e.g., '24h' or '7d')") };
+  }
+
+  const value = parseInt(periodMatch[1], 10);
+  const unit = periodMatch[2];
+  const totalDays = unit === 'd' ? value : value / 24;
+
+  // Finer intervals are capped harder to bound the rows scanned per request
+  const maxPeriodDays = interval === '1m' ? 2 : interval === '5m' ? 10 : 30;
+  if (totalDays > maxPeriodDays) {
+    return { error: badRequest(`For ${interval} interval, period cannot exceed ${maxPeriodDays} days`) };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
+
+  return {
+    range: {
+      interval,
+      intervalSeconds,
+      cacheDuration: CACHE_DURATION_SECONDS[interval],
+      startTime: now - value * multiplier,
+      now,
+    },
+  };
+}

--- a/app/api/lib/historical.ts
+++ b/app/api/lib/historical.ts
@@ -40,11 +40,12 @@ export function parseHistoricalParams(
   searchParams: URLSearchParams
 ): { error: NextResponse } | { range: HistoricalRange } {
   const interval = searchParams.get('interval') || '5m';
-  const intervalSeconds = INTERVAL_SECONDS[interval];
 
-  if (!intervalSeconds) {
+  if (!Object.hasOwn(INTERVAL_SECONDS, interval)) {
     return { error: badRequest("Interval must be one of: '1m', '5m', '15m', '30m', '1h'") };
   }
+
+  const intervalSeconds = INTERVAL_SECONDS[interval];
 
   const period = searchParams.get('period') || '24h';
   const periodMatch = period.match(/^([1-9]\d*)([dh])$/);

--- a/app/api/lib/rate-limit.ts
+++ b/app/api/lib/rate-limit.ts
@@ -54,9 +54,14 @@ export interface RateLimitResult {
 
 /**
  * Get client identifier from request
- * Uses X-Forwarded-For header if behind a proxy, falls back to generic identifier
+ * Prefers Cloudflare's single-value client IP header, then common proxy headers.
  */
 export function getClientIdentifier(request: Request): string {
+  const cloudflareIp = request.headers.get('cf-connecting-ip')?.trim();
+  if (cloudflareIp) {
+    return cloudflareIp;
+  }
+
   // Try to get real IP from common headers (when behind proxy/load balancer)
   const forwardedFor = request.headers.get('x-forwarded-for');
   if (forwardedFor) {

--- a/app/api/lib/upstream-error.ts
+++ b/app/api/lib/upstream-error.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const MAX_REFLECTED_ERROR_LENGTH = 300;
+
+/**
+ * Build a client response for a failed upstream call. Upstream 4xx bodies are
+ * first-party API errors written for consumers, so they pass through
+ * (truncated) as user-actionable detail. 5xx bodies may contain internal
+ * details, so the client gets a generic message and the body is logged.
+ */
+export async function upstreamErrorResponse(
+  response: Response,
+  fallbackMessage: string,
+  logContext: string,
+): Promise<NextResponse> {
+  const text = await response.text().catch(() => '');
+
+  if (response.status >= 500) {
+    console.error(`${logContext} (${response.status}):`, text || response.statusText);
+    return NextResponse.json({ error: fallbackMessage }, { status: response.status });
+  }
+
+  const detail = text.trim().slice(0, MAX_REFLECTED_ERROR_LENGTH);
+  return NextResponse.json(
+    { error: detail ? `${fallbackMessage}: ${detail}` : fallbackMessage },
+    { status: response.status }
+  );
+}

--- a/app/api/lightning/auth/login/route.ts
+++ b/app/api/lightning/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { isValidBitcoinAddress } from '@/app/utils/validators';
 
 export async function POST(request: Request) {
   try {
@@ -53,7 +54,7 @@ export async function POST(request: Request) {
     }
 
     if (
-      address.length < 10 || address.length > 100 ||
+      !isValidBitcoinAddress(address) ||
       public_key.length > 200 ||
       signature.length > 500 ||
       nonce.length > 200
@@ -65,7 +66,7 @@ export async function POST(request: Request) {
     }
 
     const response = await fetchWithTimeout(
-      `${lightningApiUrl}/login/${address}/auth_sign/${identifier}`,
+      `${lightningApiUrl}/login/${encodeURIComponent(address)}/auth_sign/${encodeURIComponent(identifier)}`,
       {
         method: 'POST',
         headers: {
@@ -99,4 +100,3 @@ export async function POST(request: Request) {
     );
   }
 }
-

--- a/app/api/lightning/auth/login/route.ts
+++ b/app/api/lightning/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { upstreamErrorResponse } from '@/app/api/lib/upstream-error';
 import { isValidBitcoinAddress } from '@/app/utils/validators';
 
 export async function POST(request: Request) {
@@ -7,8 +8,8 @@ export async function POST(request: Request) {
     const lightningApiUrl = process.env.LIGHTNING_API_URL;
     const identifier = process.env.LIGHTNING_API_ID;
 
-    if (!identifier) {
-      console.error('LIGHTNING_API_ID not configured');
+    if (!lightningApiUrl || !identifier) {
+      console.error('LIGHTNING_API_URL or LIGHTNING_API_ID not configured');
       return NextResponse.json(
         { error: 'Lightning authentication not configured' },
         { status: 500 }
@@ -60,7 +61,7 @@ export async function POST(request: Request) {
       nonce.length > 200
     ) {
       return NextResponse.json(
-        { error: 'Invalid field lengths' },
+        { error: 'Invalid address or field lengths' },
         { status: 400 }
       );
     }
@@ -83,11 +84,7 @@ export async function POST(request: Request) {
     );
 
     if (!response.ok) {
-      const errorText = await response.text().catch(() => response.statusText);
-      return NextResponse.json(
-        { error: `Authentication failed: ${errorText}` },
-        { status: response.status }
-      );
+      return upstreamErrorResponse(response, 'Authentication failed', 'Lightning login failed');
     }
 
     const data = await response.json();

--- a/app/api/lightning/auth/nonce/route.ts
+++ b/app/api/lightning/auth/nonce/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { isValidBitcoinAddress } from '@/app/utils/validators';
 
 export async function POST(request: Request) {
   try {
@@ -34,7 +35,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (address.length < 10 || address.length > 100) {
+    if (!isValidBitcoinAddress(address)) {
       return NextResponse.json(
         { error: 'Invalid address format' },
         { status: 400 }
@@ -42,7 +43,7 @@ export async function POST(request: Request) {
     }
 
     const response = await fetchWithTimeout(
-      `${lightningApiUrl}/login/${address}/auth_nonce/${identifier}`,
+      `${lightningApiUrl}/login/${encodeURIComponent(address)}/auth_nonce/${encodeURIComponent(identifier)}`,
       {
         method: 'GET',
         headers: {
@@ -68,4 +69,3 @@ export async function POST(request: Request) {
     );
   }
 }
-

--- a/app/api/lightning/auth/nonce/route.ts
+++ b/app/api/lightning/auth/nonce/route.ts
@@ -7,8 +7,8 @@ export async function POST(request: Request) {
     const lightningApiUrl = process.env.LIGHTNING_API_URL;
     const identifier = process.env.LIGHTNING_API_ID;
 
-    if (!identifier) {
-      console.error('LIGHTNING_API_ID not configured');
+    if (!lightningApiUrl || !identifier) {
+      console.error('LIGHTNING_API_URL or LIGHTNING_API_ID not configured');
       return NextResponse.json(
         { error: 'Lightning authentication not configured' },
         { status: 500 }

--- a/app/api/lightning/withdraw/quote/route.ts
+++ b/app/api/lightning/withdraw/quote/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { upstreamErrorResponse } from '@/app/api/lib/upstream-error';
 import { isValidBitcoinAddress } from '@/app/utils/validators';
 
 export async function POST(request: Request) {
   try {
     const lightningApiUrl = process.env.LIGHTNING_API_URL;
+
+    if (!lightningApiUrl) {
+      console.error('LIGHTNING_API_URL not configured');
+      return NextResponse.json(
+        { error: 'Lightning withdrawals not configured' },
+        { status: 500 }
+      );
+    }
 
     // Get lightning token from header
     const lightningToken = request.headers.get('X-Lightning-Token');
@@ -57,11 +66,7 @@ export async function POST(request: Request) {
     );
 
     if (!response.ok) {
-      const errorText = await response.text().catch(() => response.statusText);
-      return NextResponse.json(
-        { error: `Failed to get withdraw quote: ${errorText}` },
-        { status: response.status }
-      );
+      return upstreamErrorResponse(response, 'Failed to get withdraw quote', 'Lightning withdraw quote failed');
     }
 
     const data = await response.json();

--- a/app/api/lightning/withdraw/route.ts
+++ b/app/api/lightning/withdraw/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/app/api/lib/fetch-with-timeout';
+import { upstreamErrorResponse } from '@/app/api/lib/upstream-error';
 import { isValidBitcoinAddress } from '@/app/utils/validators';
 
 export async function POST(request: Request) {
   try {
     const lightningApiUrl = process.env.LIGHTNING_API_URL;
+
+    if (!lightningApiUrl) {
+      console.error('LIGHTNING_API_URL not configured');
+      return NextResponse.json(
+        { error: 'Lightning withdrawals not configured' },
+        { status: 500 }
+      );
+    }
 
     // Get lightning token from header
     const lightningToken = request.headers.get('X-Lightning-Token');
@@ -57,11 +66,7 @@ export async function POST(request: Request) {
     );
 
     if (!response.ok) {
-      const errorText = await response.text().catch(() => response.statusText);
-      return NextResponse.json(
-        { error: `Failed to execute withdraw: ${errorText}` },
-        { status: response.status }
-      );
+      return upstreamErrorResponse(response, 'Failed to execute withdraw', 'Lightning withdraw failed');
     }
 
     const data = await response.json();

--- a/app/api/pool-stats/historical/route.ts
+++ b/app/api/pool-stats/historical/route.ts
@@ -4,6 +4,8 @@ import { parseHashrate } from '../../../utils/formatters';
 
 export const dynamic = 'force-dynamic';
 
+const ALLOWED_INTERVALS = new Set(['1m', '5m', '15m', '30m', '1h']);
+
 function smoothAnomalies(data: HistoricalPoolStats[]): HistoricalPoolStats[] {
   if (data.length < 2) return data;
   
@@ -70,11 +72,9 @@ export async function GET(request: Request) {
     const period = searchParams.get('period') || '24h';
     const interval = searchParams.get('interval') || '5m';
     
-    // Validate interval is positive for numeric intervals
-    const intervalMatch = interval.match(/^(-?\d+)([mh])$/);
-    if (!intervalMatch || parseInt(intervalMatch[1], 10) <= 0) {
+    if (!ALLOWED_INTERVALS.has(interval)) {
       return new NextResponse(
-        JSON.stringify({ error: "Interval must be a positive value with unit (e.g., '5m', '1h')" }), 
+        JSON.stringify({ error: "Interval must be one of: '1m', '5m', '15m', '30m', '1h'" }),
         { 
           status: 400,
           headers: {
@@ -107,51 +107,44 @@ export async function GET(request: Request) {
     
     // Calculate the time range based on the period
     const now = Math.floor(Date.now() / 1000);
-    let startTime = now;
     
     // Parse period format (e.g., "18d" or "6h")
-    const periodMatch = period.match(/^(-?\d+)([dh])$/);
-    
-    if (periodMatch) {
-      const value = parseInt(periodMatch[1], 10);
-      if (value <= 0) {
-        return new NextResponse(
-          JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
-          { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-        );
-      }
-
-      const unit = periodMatch[2];
-      
-      // Calculate total days for max period check
-      const totalDays = unit === 'd' ? value : value / 24;
-      
-      // Set max period based on the selected interval
-      let maxPeriodDays = 30; // Default max
-      
-      // Apply interval-specific limits
-      if (interval === '1m') {
-        maxPeriodDays = 2; // 2 days max for 1-minute intervals
-      } else if (interval === '5m') {
-        maxPeriodDays = 10; // 10 days max for 5-minute intervals
-      }
-      
-      if (totalDays > maxPeriodDays) {
-        return new NextResponse(
-          JSON.stringify({ 
-            error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days` 
-          }),
-          { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-        );
-      }
-      
-      // Calculate seconds based on unit (d for days, h for hours)
-      const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
-      startTime = now - value * multiplier;
-    } else {
-      // Default to 24 hours if format is invalid
-      startTime = now - 24 * 60 * 60;
+    const periodMatch = period.match(/^([1-9]\d*)([dh])$/);
+    if (!periodMatch) {
+      return new NextResponse(
+        JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
+        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+      );
     }
+
+    const value = parseInt(periodMatch[1], 10);
+    const unit = periodMatch[2];
+
+    // Calculate total days for max period check
+    const totalDays = unit === 'd' ? value : value / 24;
+
+    // Set max period based on the selected interval
+    let maxPeriodDays = 30; // Default max
+
+    // Apply interval-specific limits
+    if (interval === '1m') {
+      maxPeriodDays = 2; // 2 days max for 1-minute intervals
+    } else if (interval === '5m') {
+      maxPeriodDays = 10; // 10 days max for 5-minute intervals
+    }
+
+    if (totalDays > maxPeriodDays) {
+      return new NextResponse(
+        JSON.stringify({
+          error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days`
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    // Calculate seconds based on unit (d for days, h for hours)
+    const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
+    const startTime = now - value * multiplier;
     
     // Get the data from the database
     const db = getDb();
@@ -179,19 +172,26 @@ export async function GET(request: Request) {
         intervalSeconds = 5 * 60;
     }
     
-    // Calculate intervals for the time range
-    const intervals = [];
-    for (let t = startTime; t < now; t += intervalSeconds) {
-      intervals.push({
-        start: t,
-        end: t + intervalSeconds
-      });
-    }
-    
-    // Query for each interval and aggregate
-    const results: HistoricalPoolStats[] = [];
-    
-    const stmt = db.prepare(`
+    const rows = db.prepare(`
+      WITH bucketed AS (
+        SELECT
+          users,
+          workers,
+          idle,
+          disconnected,
+          hashrate15m,
+          hashrate1hr,
+          hashrate6hr,
+          hashrate1d,
+          hashrate7d,
+          timestamp,
+          ROW_NUMBER() OVER (
+            PARTITION BY CAST((timestamp - ?) / ? AS INTEGER)
+            ORDER BY timestamp DESC
+          ) AS row_number
+        FROM pool_stats
+        WHERE timestamp >= ? AND timestamp < ?
+      )
       SELECT
         users,
         workers,
@@ -203,33 +203,29 @@ export async function GET(request: Request) {
         hashrate1d,
         hashrate7d,
         timestamp
-      FROM pool_stats
-      WHERE timestamp >= ? AND timestamp <= ?
-      ORDER BY timestamp DESC
-      LIMIT 1
-    `);
+      FROM bucketed
+      WHERE row_number = 1
+      ORDER BY timestamp ASC
+    `).all(startTime, intervalSeconds, startTime, now) as HistoricalPoolStats[];
 
-    for (const { start, end } of intervals) {
-      const clampedEnd = Math.min(end, now);
-      const row = stmt.get(start, clampedEnd) as HistoricalPoolStats | undefined;
-
-      if (row) {
-        if (row.users > 0 || row.workers > 0 || parseHashrate(row.hashrate15m) > 0 || parseHashrate(row.hashrate1d) > 0) {
-          results.push({
-            timestamp: row.timestamp,
-            users: row.users,
-            workers: row.workers,
-            idle: row.idle,
-            disconnected: row.disconnected,
-            hashrate15m: parseHashrate(row.hashrate15m),
-            hashrate1hr: parseHashrate(row.hashrate1hr),
-            hashrate6hr: parseHashrate(row.hashrate6hr),
-            hashrate1d: parseHashrate(row.hashrate1d),
-            hashrate7d: parseHashrate(row.hashrate7d)
-          });
-        }
+    const results = rows.flatMap(row => {
+      if (row.users <= 0 && row.workers <= 0 && parseHashrate(row.hashrate15m) <= 0 && parseHashrate(row.hashrate1d) <= 0) {
+        return [];
       }
-    }
+
+      return [{
+        timestamp: row.timestamp,
+        users: row.users,
+        workers: row.workers,
+        idle: row.idle,
+        disconnected: row.disconnected,
+        hashrate15m: parseHashrate(row.hashrate15m),
+        hashrate1hr: parseHashrate(row.hashrate1hr),
+        hashrate6hr: parseHashrate(row.hashrate6hr),
+        hashrate1d: parseHashrate(row.hashrate1d),
+        hashrate7d: parseHashrate(row.hashrate7d),
+      }];
+    });
     
     // Apply anomaly smoothing to filter out measurement errors
     const smoothedResults = smoothAnomalies(results);

--- a/app/api/pool-stats/historical/route.ts
+++ b/app/api/pool-stats/historical/route.ts
@@ -109,7 +109,7 @@ export async function GET(request: Request) {
     `).all(startTime, intervalSeconds, startTime, now) as HistoricalPoolStats[];
 
     const results = rows.flatMap(row => {
-      if (row.users <= 0 && row.workers <= 0 && parseHashrate(row.hashrate15m) <= 0 && parseHashrate(row.hashrate1d) <= 0) {
+      if (!(row.users > 0 || row.workers > 0 || parseHashrate(row.hashrate15m) > 0 || parseHashrate(row.hashrate1d) > 0)) {
         return [];
       }
 

--- a/app/api/pool-stats/historical/route.ts
+++ b/app/api/pool-stats/historical/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getDb } from '../../../../lib/db';
 import { parseHashrate } from '../../../utils/formatters';
+import { parseHistoricalParams } from '@/app/api/lib/historical';
 
 export const dynamic = 'force-dynamic';
-
-const ALLOWED_INTERVALS = new Set(['1m', '5m', '15m', '30m', '1h']);
 
 function smoothAnomalies(data: HistoricalPoolStats[]): HistoricalPoolStats[] {
   if (data.length < 2) return data;
@@ -66,112 +65,13 @@ export interface HistoricalPoolStats {
 
 export async function GET(request: Request) {
   try {
-    const { searchParams } = new URL(request.url);
-    
-    // Parse parameters with defaults
-    const period = searchParams.get('period') || '24h';
-    const interval = searchParams.get('interval') || '5m';
-    
-    if (!ALLOWED_INTERVALS.has(interval)) {
-      return new NextResponse(
-        JSON.stringify({ error: "Interval must be one of: '1m', '5m', '15m', '30m', '1h'" }),
-        { 
-          status: 400,
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-store'
-          }
-        }
-      );
-    }
-    
-    // Determine cache duration based on interval
-    let cacheDuration = 300; // Default 5 minutes
-    switch (interval) {
-      case '1m':
-        cacheDuration = 60; // 1 minute
-        break;
-      case '5m':
-        cacheDuration = 300; // 5 minutes
-        break;
-      case '15m':
-        cacheDuration = 900; // 15 minutes
-        break;
-      case '30m':
-        cacheDuration = 300; // 5 minutes
-        break;
-      case '1h':
-        cacheDuration = 3600; // 1 hour
-        break;
-    }
-    
-    // Calculate the time range based on the period
-    const now = Math.floor(Date.now() / 1000);
-    
-    // Parse period format (e.g., "18d" or "6h")
-    const periodMatch = period.match(/^([1-9]\d*)([dh])$/);
-    if (!periodMatch) {
-      return new NextResponse(
-        JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-      );
-    }
+    const parsed = parseHistoricalParams(new URL(request.url).searchParams);
+    if ('error' in parsed) return parsed.error;
+    const { intervalSeconds, cacheDuration, startTime, now } = parsed.range;
 
-    const value = parseInt(periodMatch[1], 10);
-    const unit = periodMatch[2];
-
-    // Calculate total days for max period check
-    const totalDays = unit === 'd' ? value : value / 24;
-
-    // Set max period based on the selected interval
-    let maxPeriodDays = 30; // Default max
-
-    // Apply interval-specific limits
-    if (interval === '1m') {
-      maxPeriodDays = 2; // 2 days max for 1-minute intervals
-    } else if (interval === '5m') {
-      maxPeriodDays = 10; // 10 days max for 5-minute intervals
-    }
-
-    if (totalDays > maxPeriodDays) {
-      return new NextResponse(
-        JSON.stringify({
-          error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days`
-        }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-      );
-    }
-
-    // Calculate seconds based on unit (d for days, h for hours)
-    const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
-    const startTime = now - value * multiplier;
-    
     // Get the data from the database
     const db = getDb();
-    
-    // Parse the interval
-    let intervalSeconds;
-    switch (interval) {
-      case '1m':
-        intervalSeconds = 60;
-        break;
-      case '5m':
-        intervalSeconds = 5 * 60;
-        break;
-      case '15m':
-        intervalSeconds = 15 * 60;
-        break;
-      case '30m':
-        intervalSeconds = 30 * 60;
-        break;
-      case '1h':
-        intervalSeconds = 60 * 60;
-        break;
-      default:
-        // Default to 5 minutes
-        intervalSeconds = 5 * 60;
-    }
-    
+
     const rows = db.prepare(`
       WITH bucketed AS (
         SELECT

--- a/app/api/rounds/route.ts
+++ b/app/api/rounds/route.ts
@@ -1,15 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
+import { formatAddress } from '@/app/utils/formatters';
 import type { RoundRow } from './types';
 
 export async function GET() {
   try {
     const db = getDb();
 
-    const rounds = db.prepare(`
+    const rows = db.prepare(`
       SELECT r.block_height, r.block_hash, r.coinbase_value, r.winner_diff, r.winner_username, r.participant_status,
+             m.is_public AS winner_is_public,
              COALESCE(w.total_work, 0) AS total_work
       FROM rounds r
+      LEFT JOIN monitored_users m ON m.address = r.winner_username
       LEFT JOIN (
         SELECT block_height, SUM(total_work) AS total_work
         FROM round_participants
@@ -17,7 +20,18 @@ export async function GET() {
       ) w ON w.block_height = r.block_height
       WHERE r.block_height != 0
       ORDER BY r.block_height DESC
-    `).all() as RoundRow[];
+    `).all() as (RoundRow & { winner_is_public: number | null })[];
+
+    // PRIVACY: only return truncated addresses, and redact winners who opted
+    // out of public listing (unmonitored winners stay visible, matching the
+    // participant queries).
+    const rounds: RoundRow[] = rows.map(({ winner_is_public, winner_username, ...row }) => ({
+      ...row,
+      winner_username:
+        winner_username && (winner_is_public === null || winner_is_public === 1)
+          ? formatAddress(winner_username)
+          : null,
+    }));
 
     // Prepend synthetic current-round entry if participant data exists
     const currentRound = db.prepare(

--- a/app/api/router/order/[id]/route.ts
+++ b/app/api/router/order/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { fetch } from '@/lib/http-client';
 
 export async function GET(
   _request: NextRequest,

--- a/app/api/router/order/route.ts
+++ b/app/api/router/order/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { fetch } from '@/lib/http-client';
 
 export async function POST(request: NextRequest) {
   const routerBase = process.env.ROUTER_API_URL;
@@ -17,6 +16,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
     });
     const contentType = res.headers.get('content-type') ?? '';
     if (contentType.includes('application/json')) {

--- a/app/api/router/order/route.ts
+++ b/app/api/router/order/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { fetch } from '@/lib/http-client';
 
 export async function POST(request: NextRequest) {
   const routerBase = process.env.ROUTER_API_URL;

--- a/app/api/router/orders/route.ts
+++ b/app/api/router/orders/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { fetch } from '@/lib/http-client';
 
 export const dynamic = 'force-dynamic';
 

--- a/app/api/router/status/route.ts
+++ b/app/api/router/status/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { fetch } from '@/lib/http-client';
 
 export async function GET() {
   const routerBase = process.env.ROUTER_API_URL;

--- a/app/api/user/[address]/badges/route.ts
+++ b/app/api/user/[address]/badges/route.ts
@@ -1,16 +1,35 @@
 import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { getBadgesCached } from '@/lib/badges-collector';
+import { isValidBitcoinAddress } from '@/app/utils/validators';
+import { checkRateLimit, getRateLimitHeaders } from '@/app/api/lib/rate-limit';
 import type { BadgesPayload } from '@/lib/badge-types';
 
 export type UserBadgesResponse = BadgesPayload;
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ address: string }> }
 ) {
+  const rateLimitResult = checkRateLimit(request);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      {
+        status: 429,
+        headers: getRateLimitHeaders(rateLimitResult),
+      }
+    );
+  }
+
   try {
     const { address } = await params;
+
+    if (!isValidBitcoinAddress(address)) {
+      return NextResponse.json({ error: 'Invalid Bitcoin address' }, { status: 400 });
+    }
+
     const db = getDb();
 
     // Privacy check: return 403 if user is private

--- a/app/api/user/[address]/historical/route.ts
+++ b/app/api/user/[address]/historical/route.ts
@@ -5,6 +5,8 @@ import { getDb } from '../../../../../lib/db';
 // Enable caching based on interval
 export const revalidate = 60;
 
+const ALLOWED_INTERVALS = new Set(['1m', '5m', '15m', '30m', '1h']);
+
 export interface HistoricalUserStats {
   timestamp: string;
   hashrate: number;
@@ -20,11 +22,9 @@ export async function GET(
     const period = searchParams.get('period') || '24h';
     const interval = searchParams.get('interval') || '5m';
 
-    // Validate interval is positive for numeric intervals
-    const intervalMatch = interval.match(/^(-?\d+)([mh])$/);
-    if (!intervalMatch || parseInt(intervalMatch[1], 10) <= 0) {
+    if (!ALLOWED_INTERVALS.has(interval)) {
       return new NextResponse(
-        JSON.stringify({ error: "Interval must be a positive value with unit (e.g., '5m', '1h')" }), 
+        JSON.stringify({ error: "Interval must be one of: '1m', '5m', '15m', '30m', '1h'" }),
         { 
           status: 400,
           headers: {
@@ -73,51 +73,44 @@ export async function GET(
     
     // Calculate the time range based on the period
     const now = Math.floor(Date.now() / 1000);
-    let startTime = now;
     
     // Parse period format (e.g., "18d" or "6h")
-    const periodMatch = period.match(/^(-?\d+)([dh])$/);
-    
-    if (periodMatch) {
-      const value = parseInt(periodMatch[1], 10);
-      if (value <= 0) {
-        return new NextResponse(
-          JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
-          { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-        );
-      }
-
-      const unit = periodMatch[2];
-      
-      // Calculate total days for max period check
-      const totalDays = unit === 'd' ? value : value / 24;
-      
-      // Set max period based on the selected interval
-      let maxPeriodDays = 30; // Default max
-      
-      // Apply interval-specific limits
-      if (interval === '1m') {
-        maxPeriodDays = 2; // 2 days max for 1-minute intervals
-      } else if (interval === '5m') {
-        maxPeriodDays = 10; // 10 days max for 5-minute intervals
-      }
-      
-      if (totalDays > maxPeriodDays) {
-        return new NextResponse(
-          JSON.stringify({ 
-            error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days` 
-          }),
-          { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-        );
-      }
-      
-      // Calculate seconds based on unit (d for days, h for hours)
-      const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
-      startTime = now - value * multiplier;
-    } else {
-      // Default to 24 hours if format is invalid
-      startTime = now - 24 * 60 * 60;
+    const periodMatch = period.match(/^([1-9]\d*)([dh])$/);
+    if (!periodMatch) {
+      return new NextResponse(
+        JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
+        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+      );
     }
+
+    const value = parseInt(periodMatch[1], 10);
+    const unit = periodMatch[2];
+
+    // Calculate total days for max period check
+    const totalDays = unit === 'd' ? value : value / 24;
+
+    // Set max period based on the selected interval
+    let maxPeriodDays = 30; // Default max
+
+    // Apply interval-specific limits
+    if (interval === '1m') {
+      maxPeriodDays = 2; // 2 days max for 1-minute intervals
+    } else if (interval === '5m') {
+      maxPeriodDays = 10; // 10 days max for 5-minute intervals
+    }
+
+    if (totalDays > maxPeriodDays) {
+      return new NextResponse(
+        JSON.stringify({
+          error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days`
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    // Calculate seconds based on unit (d for days, h for hours)
+    const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
+    const startTime = now - value * multiplier;
 
     const db = getDb();
 
@@ -153,44 +146,41 @@ export async function GET(
         intervalSeconds = 5 * 60; // Default to 5 minutes
     }
 
-    // Calculate intervals for the time range
-    const intervals = [];
-    for (let t = startTime; t < now; t += intervalSeconds) {
-      intervals.push({
-        start: t,
-        end: t + intervalSeconds
-      });
-    }
+    const rows = db.prepare(`
+      WITH bucketed AS (
+        SELECT
+          ${hashrateColumn} AS hashrate,
+          CAST((created_at - ?) / ? AS INTEGER) AS bucket,
+          ROW_NUMBER() OVER (
+            PARTITION BY CAST((created_at - ?) / ? AS INTEGER)
+            ORDER BY created_at DESC
+          ) AS row_number
+        FROM user_stats_history
+        WHERE user_id = ? AND created_at >= ? AND created_at < ?
+      )
+      SELECT hashrate, bucket
+      FROM bucketed
+      WHERE row_number = 1
+      ORDER BY bucket ASC
+    `).all(
+      startTime,
+      intervalSeconds,
+      startTime,
+      intervalSeconds,
+      user.id,
+      startTime,
+      now,
+    ) as { hashrate: string; bucket: number }[];
 
-    // Query for each interval and aggregate
-    const results: HistoricalUserStats[] = [];
+    const results = rows.flatMap(({ hashrate: rawHashrate, bucket }) => {
+      const hashrate = parseHashrate(rawHashrate);
+      if (hashrate <= 0) return [];
 
-    const stmt = db.prepare(`
-      SELECT
-        ${hashrateColumn} as hashrate,
-        created_at as timestamp
-      FROM user_stats_history
-      WHERE user_id = ? AND created_at >= ? AND created_at < ?
-      ORDER BY created_at DESC
-      LIMIT 1
-    `);
-
-    for (const { start, end } of intervals) {
-      const rows = stmt.all(user.id, start, end) as { timestamp: number; hashrate: string }[];
-
-      if (rows.length > 0) {
-        const row = rows[0];
-        const hashrate = parseHashrate(row.hashrate);
-        
-        // Only include intervals that have real data
-        if (hashrate > 0) {
-          results.push({
-            timestamp: new Date(start * 1000).toISOString(),
-            hashrate: hashrate
-          });
-        }
-      }
-    }
+      return [{
+        timestamp: new Date((startTime + bucket * intervalSeconds) * 1000).toISOString(),
+        hashrate,
+      }];
+    });
 
     return new NextResponse(JSON.stringify(results), {
       headers: {
@@ -212,4 +202,4 @@ export async function GET(
       }
     );
   }
-} 
+}

--- a/app/api/user/[address]/historical/route.ts
+++ b/app/api/user/[address]/historical/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { parseHashrate } from '../../../../utils/formatters';
 import { getDb } from '../../../../../lib/db';
+import { parseHistoricalParams } from '@/app/api/lib/historical';
 
 // Enable caching based on interval
 export const revalidate = 60;
-
-const ALLOWED_INTERVALS = new Set(['1m', '5m', '15m', '30m', '1h']);
 
 export interface HistoricalUserStats {
   timestamp: string;
@@ -18,42 +17,9 @@ export async function GET(
 ) {
   try {
     const { address } = await params;
-    const { searchParams } = new URL(request.url);
-    const period = searchParams.get('period') || '24h';
-    const interval = searchParams.get('interval') || '5m';
-
-    if (!ALLOWED_INTERVALS.has(interval)) {
-      return new NextResponse(
-        JSON.stringify({ error: "Interval must be one of: '1m', '5m', '15m', '30m', '1h'" }),
-        { 
-          status: 400,
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-store'
-          }
-        }
-      );
-    }
-
-    // Determine cache duration based on interval
-    let cacheDuration = 300; // Default 5 minutes
-    switch (interval) {
-      case '1m':
-        cacheDuration = 60; // 1 minute
-        break;
-      case '5m':
-        cacheDuration = 300; // 5 minutes
-        break;
-      case '15m':
-        cacheDuration = 900; // 15 minutes
-        break;
-      case '30m':
-        cacheDuration = 1800; // 30 minutes
-        break;
-      case '1h':
-        cacheDuration = 3600; // 1 hour
-        break;
-    }
+    const parsed = parseHistoricalParams(new URL(request.url).searchParams);
+    if ('error' in parsed) return parsed.error;
+    const { interval, intervalSeconds, cacheDuration, startTime, now } = parsed.range;
 
     // Determine which hashrate column to use based on interval
     let hashrateColumn: string;
@@ -70,47 +36,6 @@ export async function GET(
       default:
         hashrateColumn = 'hashrate5m'; // Default to 5m (covers 15m/30m)
     }
-    
-    // Calculate the time range based on the period
-    const now = Math.floor(Date.now() / 1000);
-    
-    // Parse period format (e.g., "18d" or "6h")
-    const periodMatch = period.match(/^([1-9]\d*)([dh])$/);
-    if (!periodMatch) {
-      return new NextResponse(
-        JSON.stringify({ error: "Period must be a positive value (e.g., '24h' or '7d')" }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-      );
-    }
-
-    const value = parseInt(periodMatch[1], 10);
-    const unit = periodMatch[2];
-
-    // Calculate total days for max period check
-    const totalDays = unit === 'd' ? value : value / 24;
-
-    // Set max period based on the selected interval
-    let maxPeriodDays = 30; // Default max
-
-    // Apply interval-specific limits
-    if (interval === '1m') {
-      maxPeriodDays = 2; // 2 days max for 1-minute intervals
-    } else if (interval === '5m') {
-      maxPeriodDays = 10; // 10 days max for 5-minute intervals
-    }
-
-    if (totalDays > maxPeriodDays) {
-      return new NextResponse(
-        JSON.stringify({
-          error: `For ${interval} interval, period cannot exceed ${maxPeriodDays} days`
-        }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
-      );
-    }
-
-    // Calculate seconds based on unit (d for days, h for hours)
-    const multiplier = unit === 'd' ? 24 * 60 * 60 : 60 * 60;
-    const startTime = now - value * multiplier;
 
     const db = getDb();
 
@@ -122,28 +47,6 @@ export async function GET(
         { error: "User not found or not active" },
         { status: 404 }
       );
-    }
-
-    // Calculate interval seconds for aggregation
-    let intervalSeconds;
-    switch (interval) {
-      case '1m':
-        intervalSeconds = 60;
-        break;
-      case '5m':
-        intervalSeconds = 5 * 60;
-        break;
-      case '15m':
-        intervalSeconds = 15 * 60;
-        break;
-      case '30m':
-        intervalSeconds = 30 * 60;
-        break;
-      case '1h':
-        intervalSeconds = 60 * 60;
-        break;
-      default:
-        intervalSeconds = 5 * 60; // Default to 5 minutes
     }
 
     const rows = db.prepare(`

--- a/app/api/user/[address]/historical/route.ts
+++ b/app/api/user/[address]/historical/route.ts
@@ -77,7 +77,7 @@ export async function GET(
 
     const results = rows.flatMap(({ hashrate: rawHashrate, bucket }) => {
       const hashrate = parseHashrate(rawHashrate);
-      if (hashrate <= 0) return [];
+      if (!(hashrate > 0)) return [];
 
       return [{
         timestamp: new Date((startTime + bucket * intervalSeconds) * 1000).toISOString(),

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -38,13 +38,13 @@ export async function POST(request: Request) {
     const existingUser = db.prepare('SELECT * FROM monitored_users WHERE address = ?').get(address) as MonitoredUser | undefined;
 
     if (existingUser) {
-      // If user exists but was inactive, reactivate them and reset failed attempts
+      // If user exists but was inactive, reactivate them. failed_attempts is
+      // preserved so strangers can't reset the collector's deactivation state.
       if (!existingUser.is_active) {
         db.prepare(`
-          UPDATE monitored_users 
-          SET 
+          UPDATE monitored_users
+          SET
             is_active = 1,
-            failed_attempts = 0,
             updated_at = ?
           WHERE address = ?
         `).run(now, address);

--- a/app/components/dispenser/DispenserClaim.tsx
+++ b/app/components/dispenser/DispenserClaim.tsx
@@ -84,6 +84,18 @@ function buildAuctionMessage(
     return `${username}|${tier}|${tierSlotIndex}|auction`;
 }
 
+function getSafeClaimUrl(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+
+    try {
+        const url = new URL(value, window.location.origin);
+        if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+        return url.toString();
+    } catch {
+        return null;
+    }
+}
+
 // Surface real failures but stay quiet when the user simply cancels signing.
 function getClaimErrorMessage(err: unknown): string | null {
     if (err instanceof SignCancelledError) {
@@ -405,8 +417,9 @@ export default function DispenserClaim({ userId, className = "", collapsed = fal
             setLocalClaimed((prev) => new Set(prev).add(slotIndex));
 
             // Link assets dispense a redemption URL, redirect to it
-            if (data.claim_url) {
-                window.location.assign(data.claim_url);
+            const claimUrl = getSafeClaimUrl(data.claim_url);
+            if (claimUrl) {
+                window.location.assign(claimUrl);
                 return;
             }
         } catch (err) {
@@ -457,8 +470,9 @@ export default function DispenserClaim({ userId, className = "", collapsed = fal
             setManualDestination("");
 
             // Link assets dispense a redemption URL, redirect to it
-            if (data.claim_url) {
-                window.location.assign(data.claim_url);
+            const claimUrl = getSafeClaimUrl(data.claim_url);
+            if (claimUrl) {
+                window.location.assign(claimUrl);
                 return;
             }
         } catch (err) {

--- a/app/components/dispenser/DispenserClaim.tsx
+++ b/app/components/dispenser/DispenserClaim.tsx
@@ -85,7 +85,7 @@ function buildAuctionMessage(
 }
 
 function getSafeClaimUrl(value: unknown): string | null {
-    if (typeof value !== "string") return null;
+    if (typeof value !== "string" || value === "") return null;
 
     try {
         const url = new URL(value, window.location.origin);
@@ -422,6 +422,9 @@ export default function DispenserClaim({ userId, className = "", collapsed = fal
                 window.location.assign(claimUrl);
                 return;
             }
+            if (data.claim_url) {
+                setError(`Claimed, but the redemption link could not be opened automatically: ${data.claim_url}`);
+            }
         } catch (err) {
             console.error("Claim error:", err);
             setError(getClaimErrorMessage(err));
@@ -474,6 +477,9 @@ export default function DispenserClaim({ userId, className = "", collapsed = fal
             if (claimUrl) {
                 window.location.assign(claimUrl);
                 return;
+            }
+            if (data.claim_url) {
+                setError(`Claimed, but the redemption link could not be opened automatically: ${data.claim_url}`);
             }
         } catch (err) {
             console.error("Manual claim error:", err);

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -331,7 +331,9 @@ export default function UserDashboard() {
         ]);
         if (mounted) {
           setRoundsData(rounds);
-          setBadgesData(badges);
+          if (badges !== null) {
+            setBadgesData(badges);
+          }
         }
       } catch (err) {
         console.error('Error fetching rounds data:', err);

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -271,7 +271,7 @@ export async function getUserBadges(address: string): Promise<BadgesPayload | nu
   try {
     return await withRetry(async () => {
       const response = await fetch(`/api/user/${address}/badges`);
-      if (response.status === 403 || response.status === 404) {
+      if (response.status === 403 || response.status === 404 || response.status === 429) {
         return null;
       }
       if (!response.ok) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ const eslintConfig = [
   },
   ...nextPlugin,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     rules: {
       "@typescript-eslint/no-unused-vars": "warn",
       "react-hooks/set-state-in-effect": "off",

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,8 +20,8 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        // Apply security headers to all API routes
-        source: '/api/:path*',
+        // Apply security headers to all routes
+        source: '/:path*',
         headers: [
           {
             key: 'X-Content-Type-Options',
@@ -43,12 +43,10 @@ const nextConfig: NextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
           },
-        ],
-      },
-      {
-        // Apply HSTS to all routes (enforce HTTPS)
-        source: '/:path*',
-        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+          },
           {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-qr-code": "2.2.0",
     "reflect-metadata": "0.2.2",
     "sharp": "0.35.3",
-    "undici": "^8.7.0"
+    "undici": "^8.10.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   axios@<1.15.2: '>=1.15.2'
   esbuild@<0.28.1: '>=0.28.1'
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.23: '>=8.5.23'
   sharp@<0.35.0: '>=0.35.0'
   ws@<8.20.1: '>=8.20.1'
 
@@ -61,8 +61,8 @@ importers:
         specifier: 0.35.3
         version: 0.35.3(@types/node@24.13.3)
       undici:
-        specifier: ^8.7.0
-        version: 8.7.0
+        specifier: ^8.10.0
+        version: 8.10.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.6
@@ -1110,12 +1110,12 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1790,8 +1790,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1975,8 +1975,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2143,8 +2143,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2498,8 +2498,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@8.7.0:
-    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unrs-resolver@1.12.2:
@@ -2825,7 +2825,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3130,7 +3130,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.19
+      postcss: 8.5.26
       tailwindcss: 4.3.2
 
   '@tybys/wasm-util@0.10.3':
@@ -3493,12 +3493,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4358,7 +4358,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -4490,11 +4490,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -4508,7 +4508,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -4522,7 +4522,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.19
+      postcss: 8.5.26
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.7)
@@ -4678,9 +4678,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5128,7 +5128,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@8.7.0: {}
+  undici@8.10.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ verifyDepsBeforeRun: error
 overrides:
   axios@<1.15.2: '>=1.15.2'
   esbuild@<0.28.1: '>=0.28.1'
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.23: '>=8.5.23'
   sharp@<0.35.0: '>=0.35.0'
   ws@<8.20.1: '>=8.20.1'
 


### PR DESCRIPTION
Harden several public request boundaries and remove the expensive per-bucket history query loops.

- apply existing security headers to pages and add conservative CSP frame protections
- validate and encode Lightning auth addresses, and prefer the Cloudflare client IP for rate limiting
- limit dispenser claim redirects to HTTP(S)
- restrict history interval and period values, then fetch the latest sample per bucket in one query for both pool and user history
- update Undici and audit-affected transitive dependencies
- scope the TypeScript ESLint override to TypeScript files so clean installs lint correctly

Historical query output was compared with the previous implementation against local data and selected the same rows. Production and development audits are clean. Lint, TypeScript, and the production build pass.

Note: These findings were done with the help of Kimi, as I wanted to try it after the recent attention its gotten